### PR TITLE
[codex] linalg: add dense LAPACK helpers

### DIFF
--- a/docs/architecture_diagram.md
+++ b/docs/architecture_diagram.md
@@ -24,7 +24,7 @@ graph TD
         Kernel[Kernel dispatch]
         Async[Async runtime]
         Common[Common/core utilities]
-        Expokit[Expokit integration]
+        DenseExp[CPU dense matrix exponential]
     end
 
     subgraph AsyncRuntime[Async Runtime Details]
@@ -56,7 +56,7 @@ graph TD
     Uni20Lib --> Kernel
     Uni20Lib --> Async
     Uni20Lib --> Common
-    Uni20Lib --> Expokit
+    Uni20Lib --> DenseExp
 
     Tensor --> Mdspan
     Level1 --> Kernel

--- a/docs/backend_dispatch.md
+++ b/docs/backend_dispatch.md
@@ -276,6 +276,27 @@ ABI is available, put the Fortran wrapper behind a Uni20 C-like adapter so
 algorithm lowering code does not depend on symbol mangling or Fortran integer
 details.
 
+The low-level LAPACK facade currently follows a two-layer convention:
+
+- `uni20::lapack::unchecked` contains type-safe, provider-backed overloads that
+  return the raw LAPACK `INFO` value. These wrappers are marked `[[nodiscard]]`
+  and are the right layer for algorithms that want to handle singularity,
+  non-convergence, workspace queries, condition warnings, or fallback policy
+  themselves.
+- `uni20::lapack` contains thin checked wrappers that call the corresponding
+  unchecked overload and throw with diagnostic context for ordinary fatal
+  statuses such as invalid arguments, singular factors, or convergence failure.
+  This layer should not contain algorithmic fallback policy. Higher-level
+  helpers such as `svd`, `solve`, or tensor truncation routines can call
+  `unchecked` directly when they need trial algorithms or richer recovery.
+
+The provider is a physical implementation detail, not part of the public call
+surface. Standard LAPACK overloads and MPLAPACK binary128 overloads should
+present the same `uni20::lapack::unchecked::<routine>` spelling when they
+provide the same operation. Future global kernel dispatch can then detect
+compile-time callability and runtime suitability without hard-coding provider
+names into algorithm code.
+
 ## Applicability
 
 This pattern is not BLAS-specific. Use it for future optimized paths involving:

--- a/src/uni20/backend/backend.hpp
+++ b/src/uni20/backend/backend.hpp
@@ -14,6 +14,7 @@
  *
  * \par Submodules
  * - \ref backend_blas — BLAS integration and vendor selection utilities.
+ * - \ref backend_lapack — LAPACK integration and dense linear algebra adapters.
  * - \ref backend_cuda — CUDA runtime orchestration helpers.
  * - \ref backend_cusolver — cuSOLVER-specific linear algebra adapters.
  */
@@ -42,6 +43,15 @@
  */
 
 /**
+ * \defgroup backend_lapack LAPACK backend integration
+ * \ingroup backend
+ * \brief Glue that binds Uni20 abstractions to LAPACK-compatible dense linear algebra providers.
+ *
+ * \par Submodules
+ * - \ref backend_lapack_reference — Reference LAPACK wrappers for float and double.
+ */
+
+/**
  * \defgroup internal Backend implementation details
  * \ingroup backend
  * \brief Internal macros and helpers that support backend integrations without being part of the
@@ -54,14 +64,14 @@
 /// \ingroup internal
 #define UNI20_INTERNAL_STRINGIFY_TOKEN(x) #x
 
-/// \brief Produces the log-friendly spelling of a backend API symbol.
+/// \brief Produces the log-friendly spelling of an external backend API symbol.
 /// \param func Macro argument that names the symbol being traced.
 /// \return String literal suitable for concatenating into trace output.
 /// \ingroup internal
 #define UNI20_INTERNAL_API_CALL_STRINGIZE(func) UNI20_INTERNAL_STRINGIFY_TOKEN(func)
 
 /// \brief Emits a trace log entry for an outgoing backend API call.
-/// \details This macro wraps \ref TRACE_MODULE so every backend API call records a side
+/// \details This macro wraps \ref TRACE_MODULE so every external backend API call records a side
 ///          effect visible to the tracing subsystem.
 /// \param module Name of the backend module emitting the trace entry. This must match one of
 ///        the trace channels registered in the top-level CMake configuration.
@@ -70,5 +80,6 @@
 /// \param ... Optional comma-separated arguments that mirror the runtime parameters forwarded to
 ///        the backend function. Each argument is appended to the trace entry when provided.
 /// \ingroup backend
-#define UNI20_API_CALL(module, func, ...)                                                                              \
-  TRACE_MODULE(module, "Calling API function " UNI20_INTERNAL_API_CALL_STRINGIZE(func) __VA_OPT__(, __VA_ARGS__))
+#define UNI20_EXTERNAL_API_CALL(module, func, ...)                                                                     \
+  TRACE_MODULE(module,                                                                                                 \
+               "Calling external API function " UNI20_INTERNAL_API_CALL_STRINGIZE(func) __VA_OPT__(, __VA_ARGS__))

--- a/src/uni20/backend/blas/CMakeLists.txt
+++ b/src/uni20/backend/blas/CMakeLists.txt
@@ -31,12 +31,17 @@ detect_blas_vendor()
 
 add_library(uni20_interface_blas INTERFACE)
 
-# Add the BLAS libraries to the interface link line
-target_link_libraries(uni20_interface_blas INTERFACE ${BLAS_LIBRARIES})
+# Add the BLAS/LAPACK libraries to the interface link line. The LAPACK headers
+# are currently header-only wrappers discovered with the BLAS backend.
+target_link_libraries(uni20_interface_blas INTERFACE ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 
 # If FindBLAS sets BLAS_LINKER_FLAGS, attach them to link options:
 if(BLAS_LINKER_FLAGS)
   target_link_options(uni20_interface_blas INTERFACE ${BLAS_LINKER_FLAGS})
+endif()
+
+if(LAPACK_LINKER_FLAGS)
+  target_link_options(uni20_interface_blas INTERFACE ${LAPACK_LINKER_FLAGS})
 endif()
 
 add_library(uni20_backend_blas STATIC

--- a/src/uni20/backend/blas/reference/detail/blasproto.hpp
+++ b/src/uni20/backend/blas/reference/detail/blasproto.hpp
@@ -16,7 +16,7 @@
 /// - `BLASCOMPLEX`: Either `0` (for real types) or `1` (for complex types).
 ///
 /// Each inclusion generates extern "C" declarations and inline C++ overloads,
-/// optionally including trace hooks via `UNI20_API_CALL`.
+/// optionally including trace hooks via `UNI20_EXTERNAL_API_CALL`.
 ///
 /// \note This file must not use `#pragma once` or include guards.
 ///
@@ -121,14 +121,15 @@ extern "C"
 inline void gemm(char transa, char transb, blas_int m, blas_int n, blas_int k, BLASTYPE alpha, BLASTYPE const* A,
                  blas_int lda, BLASTYPE const* B, blas_int ldb, BLASTYPE beta, BLASTYPE* C, blas_int ldc)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(gemm), transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(gemm), transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C,
+                          ldc);
   detail::UNI20_INTERNAL_BLAS_FN(gemm)(&transa, &transb, &m, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
 }
 
 inline void gemv(char trans, blas_int m, blas_int n, BLASTYPE alpha, BLASTYPE const* A, blas_int lda, BLASTYPE const* x,
                  blas_int incx, BLASTYPE beta, BLASTYPE* y, blas_int incy)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(gemv), trans, m, n, alpha, A, lda, x, incx, beta, y, incy);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(gemv), trans, m, n, alpha, A, lda, x, incx, beta, y, incy);
   detail::UNI20_INTERNAL_BLAS_FN(gemv)(&trans, &m, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
 }
 
@@ -137,28 +138,28 @@ inline void gemv(char trans, blas_int m, blas_int n, BLASTYPE alpha, BLASTYPE co
 inline void geru(blas_int m, blas_int n, BLASTYPE alpha, BLASTYPE const* x, blas_int incx, BLASTYPE const* y,
                  blas_int incy, BLASTYPE* A, blas_int lda)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(geru), m, n, alpha, x, incx, y, incy, A, lda);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(geru), m, n, alpha, x, incx, y, incy, A, lda);
   detail::UNI20_INTERNAL_BLAS_FN(geru)(&m, &n, &alpha, x, &incx, y, &incy, A, &lda);
 }
 
 inline void gerc(blas_int m, blas_int n, BLASTYPE alpha, BLASTYPE const* x, blas_int incx, BLASTYPE const* y,
                  blas_int incy, BLASTYPE* A, blas_int lda)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(gerc), m, n, alpha, x, incx, y, incy, A, lda);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(gerc), m, n, alpha, x, incx, y, incy, A, lda);
   detail::UNI20_INTERNAL_BLAS_FN(gerc)(&m, &n, &alpha, x, &incx, y, &incy, A, &lda);
 }
 
 inline void herk(char uplo, char trans, blas_int n, blas_int k, BLASREALTYPE alpha, BLASTYPE const* A, blas_int lda,
                  BLASREALTYPE beta, BLASTYPE* C, blas_int ldc)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(herk), uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(herk), uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
   detail::UNI20_INTERNAL_BLAS_FN(herk)(&uplo, &trans, &n, &k, &alpha, A, &lda, &beta, C, &ldc);
 }
 
 inline void her2k(char uplo, char trans, blas_int n, blas_int k, BLASTYPE alpha, BLASTYPE const* A, blas_int lda,
                   BLASTYPE const* B, blas_int ldb, BLASREALTYPE beta, BLASTYPE* C, blas_int ldc)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(her2k), uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(her2k), uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
   detail::UNI20_INTERNAL_BLAS_FN(her2k)(&uplo, &trans, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
 }
 
@@ -167,21 +168,21 @@ inline void her2k(char uplo, char trans, blas_int n, blas_int k, BLASTYPE alpha,
 inline void ger(blas_int m, blas_int n, BLASTYPE alpha, BLASTYPE const* x, blas_int incx, BLASTYPE const* y,
                 blas_int incy, BLASTYPE* A, blas_int lda)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(ger), m, n, alpha, x, incx, y, incy, A, lda);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(ger), m, n, alpha, x, incx, y, incy, A, lda);
   detail::UNI20_INTERNAL_BLAS_FN(ger)(&m, &n, &alpha, x, &incx, y, &incy, A, &lda);
 }
 
 inline void syrk(char uplo, char trans, blas_int n, blas_int k, BLASTYPE alpha, BLASTYPE const* A, blas_int lda,
                  BLASTYPE beta, BLASTYPE* C, blas_int ldc)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(syrk), uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(syrk), uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
   detail::UNI20_INTERNAL_BLAS_FN(syrk)(&uplo, &trans, &n, &k, &alpha, A, &lda, &beta, C, &ldc);
 }
 
 inline void syr2k(char uplo, char trans, blas_int n, blas_int k, BLASTYPE alpha, BLASTYPE const* A, blas_int lda,
                   BLASTYPE const* B, blas_int ldb, BLASTYPE beta, BLASTYPE* C, blas_int ldc)
 {
-  UNI20_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(syr2k), uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+  UNI20_EXTERNAL_API_CALL(BLAS, UNI20_INTERNAL_BLAS_FN(syr2k), uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
   detail::UNI20_INTERNAL_BLAS_FN(syr2k)(&uplo, &trans, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
 }
 #endif

--- a/src/uni20/backend/lapack/common.hpp
+++ b/src/uni20/backend/lapack/common.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+/**
+ * \file common.hpp
+ * \ingroup backend_lapack
+ * \brief Shared helpers for LAPACK backend wrappers.
+ */
+
+#include <uni20/config.hpp>
+
+namespace uni20::lapack::detail
+{
+
+template <typename> inline constexpr bool dependent_false_v = false;
+
+} // namespace uni20::lapack::detail

--- a/src/uni20/backend/lapack/lapack.hpp
+++ b/src/uni20/backend/lapack/lapack.hpp
@@ -1,0 +1,366 @@
+#pragma once
+
+/**
+ * \file lapack.hpp
+ * \ingroup backend_lapack
+ * \brief Checked LAPACK wrappers over provider-specific unchecked overloads.
+ */
+
+#include <uni20/backend/lapack/common.hpp>
+#include <uni20/backend/lapack/reference/band.hpp>
+#include <uni20/backend/lapack/reference/general.hpp>
+#include <uni20/backend/lapack/reference/norms.hpp>
+#include <uni20/backend/lapack/reference/tridiagonal.hpp>
+#include <uni20/config.hpp>
+#include <uni20/core/scalar_concepts.hpp>
+
+#include <stdexcept>
+#include <string>
+
+namespace uni20::lapack
+{
+
+namespace detail
+{
+
+[[noreturn]] inline void throw_invalid_argument_info(char const* routine, blas_int info)
+{
+  throw std::invalid_argument("LAPACK " + std::string(routine) + " received invalid argument " + std::to_string(-info));
+}
+
+[[noreturn]] inline void throw_runtime_info(char const* routine, char const* message, blas_int info)
+{
+  throw std::runtime_error("LAPACK " + std::string(routine) + " " + message + " (info=" + std::to_string(info) + ")");
+}
+
+inline void check_invalid_argument(char const* routine, blas_int info)
+{
+  if (info < 0)
+  {
+    throw_invalid_argument_info(routine, info);
+  }
+}
+
+inline void check_singular(char const* routine, blas_int info)
+{
+  check_invalid_argument(routine, info);
+  if (info > 0)
+  {
+    throw_runtime_info(routine, "found a singular matrix", info);
+  }
+}
+
+inline void check_convergence(char const* routine, blas_int info)
+{
+  check_invalid_argument(routine, info);
+  if (info > 0)
+  {
+    throw_runtime_info(routine, "failed to converge", info);
+  }
+}
+
+inline bool check_expert_solve(char const* routine, blas_int n, blas_int info)
+{
+  check_invalid_argument(routine, info);
+  if (info > 0 && info <= n)
+  {
+    throw_runtime_info(routine, "found a singular matrix", info);
+  }
+  if (info > n + 1)
+  {
+    throw_runtime_info(routine, "failed unexpectedly", info);
+  }
+  return info == n + 1;
+}
+
+inline void check_equilibration(char const* routine, blas_int m, blas_int info)
+{
+  check_invalid_argument(routine, info);
+  if (info > 0 && info <= m)
+  {
+    throw_runtime_info(routine, "found an exactly zero row", info);
+  }
+  if (info > m)
+  {
+    throw_runtime_info(routine, "found an exactly zero column", info);
+  }
+}
+
+} // namespace detail
+
+/// \brief Compute a dense real matrix norm through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+Scalar lange(char norm, blas_int m, blas_int n, Scalar* a, blas_int lda, Scalar* work)
+{
+  return unchecked::lange(norm, m, n, a, lda, work);
+}
+
+/// \brief Compute a dense real symmetric matrix norm through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+Scalar lansy(char norm, char uplo, blas_int n, Scalar* a, blas_int lda, Scalar* work)
+{
+  return unchecked::lansy(norm, uplo, n, a, lda, work);
+}
+
+/// \brief Compute a dense real triangular or trapezoidal matrix norm through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+Scalar lantr(char norm, char uplo, char diag, blas_int m, blas_int n, Scalar* a, blas_int lda, Scalar* work)
+{
+  return unchecked::lantr(norm, uplo, diag, m, n, a, lda, work);
+}
+
+/// \brief Compute a real general-band matrix norm through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+Scalar langb(char norm, blas_int n, blas_int kl, blas_int ku, Scalar* ab, blas_int ldab, Scalar* work)
+{
+  return unchecked::langb(norm, n, kl, ku, ab, ldab, work);
+}
+
+/// \brief Solve a real general-band linear system through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+void gbsv(blas_int n, blas_int kl, blas_int ku, blas_int nrhs, Scalar* ab, blas_int ldab, blas_int* ipiv, Scalar* b,
+          blas_int ldb)
+{
+  blas_int const info = unchecked::gbsv(n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb);
+  detail::check_singular("gbsv", info);
+}
+
+/// \brief Compute a real general-band LU factorization through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+void gbtrf(blas_int m, blas_int n, blas_int kl, blas_int ku, Scalar* ab, blas_int ldab, blas_int* ipiv)
+{
+  blas_int const info = unchecked::gbtrf(m, n, kl, ku, ab, ldab, ipiv);
+  detail::check_singular("gbtrf", info);
+}
+
+/// \brief Solve using an existing real general-band LU factorization.
+template <uni20::LapackReal Scalar>
+void gbtrs(char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs, Scalar* ab, blas_int ldab,
+           blas_int const* ipiv, Scalar* b, blas_int ldb)
+{
+  blas_int const info = unchecked::gbtrs(trans, n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb);
+  detail::check_invalid_argument("gbtrs", info);
+}
+
+/// \brief Estimate a real general-band reciprocal condition number.
+template <uni20::LapackReal Scalar>
+Scalar gbcon(char norm, blas_int n, blas_int kl, blas_int ku, Scalar* ab, blas_int ldab, blas_int const* ipiv,
+             Scalar anorm, Scalar* work, blas_int* iwork)
+{
+  Scalar rcond{};
+  blas_int const info = unchecked::gbcon(norm, n, kl, ku, ab, ldab, ipiv, anorm, rcond, work, iwork);
+  detail::check_invalid_argument("gbcon", info);
+  return rcond;
+}
+
+/// \brief Refine a real general-band linear-system solve and return LAPACK diagnostics.
+template <uni20::LapackReal Scalar>
+void gbrfs(char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs, Scalar* ab, blas_int ldab, Scalar* afb,
+           blas_int ldafb, blas_int const* ipiv, Scalar* b, blas_int ldb, Scalar* x, blas_int ldx,
+           Scalar* forward_error, Scalar* backward_error, Scalar* work, blas_int* iwork)
+{
+  blas_int const info = unchecked::gbrfs(trans, n, kl, ku, nrhs, ab, ldab, afb, ldafb, ipiv, b, ldb, x, ldx,
+                                         forward_error, backward_error, work, iwork);
+  detail::check_invalid_argument("gbrfs", info);
+}
+
+/// \brief Solve a real general-band linear system with LAPACK expert-driver diagnostics.
+template <uni20::LapackReal Scalar>
+bool gbsvx(char fact, char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs, Scalar* ab, blas_int ldab,
+           Scalar* afb, blas_int ldafb, blas_int* ipiv, char& equed, Scalar* row_scale, Scalar* column_scale, Scalar* b,
+           blas_int ldb, Scalar* x, blas_int ldx, Scalar& rcond, Scalar* forward_error, Scalar* backward_error,
+           Scalar* work, blas_int* iwork)
+{
+  blas_int const info =
+      unchecked::gbsvx(fact, trans, n, kl, ku, nrhs, ab, ldab, afb, ldafb, ipiv, equed, row_scale, column_scale, b, ldb,
+                       x, ldx, rcond, forward_error, backward_error, work, iwork);
+  return detail::check_expert_solve("gbsvx", n, info);
+}
+
+/// \brief Compute real general-band row/column equilibration factors.
+template <uni20::LapackReal Scalar>
+void gbequ(bool power_of_two, blas_int m, blas_int n, blas_int kl, blas_int ku, Scalar* ab, blas_int ldab,
+           Scalar* row_scale, Scalar* column_scale, Scalar& row_condition, Scalar& column_condition, Scalar& max_abs)
+{
+  blas_int const info = unchecked::gbequ(power_of_two, m, n, kl, ku, ab, ldab, row_scale, column_scale, row_condition,
+                                         column_condition, max_abs);
+  detail::check_equilibration("gbequ", m, info);
+}
+
+/// \brief Solve a real dense general linear system through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+void gesv(blas_int n, blas_int nrhs, Scalar* a, blas_int lda, blas_int* ipiv, Scalar* b, blas_int ldb)
+{
+  blas_int const info = unchecked::gesv(n, nrhs, a, lda, ipiv, b, ldb);
+  detail::check_singular("gesv", info);
+}
+
+/// \brief Solve a real dense general linear system with LAPACK expert-driver diagnostics.
+template <uni20::LapackReal Scalar>
+bool gesvx(char fact, char trans, blas_int n, blas_int nrhs, Scalar* a, blas_int lda, Scalar* af, blas_int ldaf,
+           blas_int* ipiv, char& equed, Scalar* row_scale, Scalar* column_scale, Scalar* b, blas_int ldb, Scalar* x,
+           blas_int ldx, Scalar& rcond, Scalar* forward_error, Scalar* backward_error, Scalar* work, blas_int* iwork)
+{
+  blas_int const info = unchecked::gesvx(fact, trans, n, nrhs, a, lda, af, ldaf, ipiv, equed, row_scale, column_scale,
+                                         b, ldb, x, ldx, rcond, forward_error, backward_error, work, iwork);
+  return detail::check_expert_solve("gesvx", n, info);
+}
+
+/// \brief Compute real dense general row/column equilibration factors.
+template <uni20::LapackReal Scalar>
+void geequ(blas_int m, blas_int n, Scalar* a, blas_int lda, Scalar* row_scale, Scalar* column_scale,
+           Scalar& row_condition, Scalar& column_condition, Scalar& max_abs)
+{
+  blas_int const info =
+      unchecked::geequ(m, n, a, lda, row_scale, column_scale, row_condition, column_condition, max_abs);
+  detail::check_equilibration("geequ", m, info);
+}
+
+/// \brief Compute a real dense general LU factorization through the configured LAPACK backend.
+template <uni20::LapackReal Scalar> void getrf(blas_int m, blas_int n, Scalar* a, blas_int lda, blas_int* ipiv)
+{
+  blas_int const info = unchecked::getrf(m, n, a, lda, ipiv);
+  detail::check_singular("getrf", info);
+}
+
+/// \brief Solve using an existing real dense general LU factorization.
+template <uni20::LapackReal Scalar>
+void getrs(char trans, blas_int n, blas_int nrhs, Scalar* a, blas_int lda, blas_int const* ipiv, Scalar* b,
+           blas_int ldb)
+{
+  blas_int const info = unchecked::getrs(trans, n, nrhs, a, lda, ipiv, b, ldb);
+  detail::check_invalid_argument("getrs", info);
+}
+
+/// \brief Refine a real dense general linear-system solve and return LAPACK diagnostics.
+template <uni20::LapackReal Scalar>
+void gerfs(char trans, blas_int n, blas_int nrhs, Scalar* a, blas_int lda, Scalar* factors, blas_int factor_lda,
+           blas_int const* ipiv, Scalar* b, blas_int ldb, Scalar* x, blas_int ldx, Scalar* forward_error,
+           Scalar* backward_error, Scalar* work, blas_int* iwork)
+{
+  blas_int const info = unchecked::gerfs(trans, n, nrhs, a, lda, factors, factor_lda, ipiv, b, ldb, x, ldx,
+                                         forward_error, backward_error, work, iwork);
+  detail::check_invalid_argument("gerfs", info);
+}
+
+/// \brief Invert a real dense general matrix from an existing LU factorization.
+template <uni20::LapackReal Scalar>
+void getri(blas_int n, Scalar* a, blas_int lda, blas_int* ipiv, Scalar* work, blas_int lwork)
+{
+  blas_int const info = unchecked::getri(n, a, lda, ipiv, work, lwork);
+  detail::check_singular("getri", info);
+}
+
+/// \brief Estimate a real dense general reciprocal condition number.
+template <uni20::LapackReal Scalar>
+Scalar gecon(char norm, blas_int n, Scalar const* a, blas_int lda, Scalar anorm, Scalar* work, blas_int* iwork)
+{
+  Scalar rcond{};
+  blas_int const info = unchecked::gecon(norm, n, a, lda, anorm, rcond, work, iwork);
+  detail::check_invalid_argument("gecon", info);
+  return rcond;
+}
+
+/// \brief Solve a real dense general least-squares problem through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+void gels(char trans, blas_int m, blas_int n, blas_int nrhs, Scalar* a, blas_int lda, Scalar* b, blas_int ldb,
+          Scalar* work, blas_int lwork)
+{
+  blas_int const info = unchecked::gels(trans, m, n, nrhs, a, lda, b, ldb, work, lwork);
+  detail::check_invalid_argument("gels", info);
+  if (info > 0)
+  {
+    detail::throw_runtime_info("gels", "found a rank-deficient triangular factor", info);
+  }
+}
+
+/// \brief Solve a real dense general least-squares problem by SVD.
+template <uni20::LapackReal Scalar>
+void gelss(blas_int m, blas_int n, blas_int nrhs, Scalar* a, blas_int lda, Scalar* b, blas_int ldb, Scalar* s,
+           Scalar rcond, blas_int& rank, Scalar* work, blas_int lwork)
+{
+  blas_int const info = unchecked::gelss(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork);
+  detail::check_convergence("gelss", info);
+}
+
+/// \brief Solve a real dense general least-squares problem by divide-and-conquer SVD.
+template <uni20::LapackReal Scalar>
+void gelsd(blas_int m, blas_int n, blas_int nrhs, Scalar* a, blas_int lda, Scalar* b, blas_int ldb, Scalar* s,
+           Scalar rcond, blas_int& rank, Scalar* work, blas_int lwork, blas_int* iwork)
+{
+  blas_int const info = unchecked::gelsd(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, iwork);
+  detail::check_convergence("gelsd", info);
+}
+
+/// \brief Solve a real dense general least-squares problem by complete orthogonal factorization.
+template <uni20::LapackReal Scalar>
+void gelsy(blas_int m, blas_int n, blas_int nrhs, Scalar* a, blas_int lda, Scalar* b, blas_int ldb, blas_int* jpvt,
+           Scalar rcond, blas_int& rank, Scalar* work, blas_int lwork)
+{
+  blas_int const info = unchecked::gelsy(m, n, nrhs, a, lda, b, ldb, jpvt, rcond, rank, work, lwork);
+  detail::check_invalid_argument("gelsy", info);
+  if (info > 0)
+  {
+    detail::throw_runtime_info("gelsy", "failed to compute a rank-revealing least-squares solution", info);
+  }
+}
+
+/// \brief Solve a real tridiagonal linear system through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+void gtsv(blas_int n, blas_int nrhs, Scalar* dl, Scalar* d, Scalar* du, Scalar* b, blas_int ldb)
+{
+  blas_int const info = unchecked::gtsv(n, nrhs, dl, d, du, b, ldb);
+  detail::check_singular("gtsv", info);
+}
+
+/// \brief Compute a real tridiagonal LU factorization through the configured LAPACK backend.
+template <uni20::LapackReal Scalar>
+void gttrf(blas_int n, Scalar* dl, Scalar* d, Scalar* du, Scalar* du2, blas_int* ipiv)
+{
+  blas_int const info = unchecked::gttrf(n, dl, d, du, du2, ipiv);
+  detail::check_singular("gttrf", info);
+}
+
+/// \brief Solve using an existing real tridiagonal LU factorization.
+template <uni20::LapackReal Scalar>
+void gttrs(char trans, blas_int n, blas_int nrhs, Scalar* dl, Scalar* d, Scalar* du, Scalar* du2, blas_int const* ipiv,
+           Scalar* b, blas_int ldb)
+{
+  blas_int const info = unchecked::gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb);
+  detail::check_invalid_argument("gttrs", info);
+}
+
+/// \brief Estimate a real tridiagonal reciprocal condition number.
+template <uni20::LapackReal Scalar>
+Scalar gtcon(char norm, blas_int n, Scalar* dl, Scalar* d, Scalar* du, Scalar* du2, blas_int const* ipiv,
+             Scalar matrix_norm, Scalar* work, blas_int* iwork)
+{
+  Scalar rcond{};
+  blas_int const info = unchecked::gtcon(norm, n, dl, d, du, du2, ipiv, matrix_norm, rcond, work, iwork);
+  detail::check_invalid_argument("gtcon", info);
+  return rcond;
+}
+
+/// \brief Refine a real tridiagonal linear-system solve and return LAPACK diagnostics.
+template <uni20::LapackReal Scalar>
+void gtrfs(char trans, blas_int n, blas_int nrhs, Scalar* dl, Scalar* d, Scalar* du, Scalar* dlf, Scalar* df,
+           Scalar* duf, Scalar* du2, blas_int const* ipiv, Scalar* b, blas_int ldb, Scalar* x, blas_int ldx,
+           Scalar* forward_error, Scalar* backward_error, Scalar* work, blas_int* iwork)
+{
+  blas_int const info = unchecked::gtrfs(trans, n, nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, ldb, x, ldx,
+                                         forward_error, backward_error, work, iwork);
+  detail::check_invalid_argument("gtrfs", info);
+}
+
+/// \brief Solve a real tridiagonal linear system with LAPACK expert-driver diagnostics.
+template <uni20::LapackReal Scalar>
+bool gtsvx(char fact, char trans, blas_int n, blas_int nrhs, Scalar* dl, Scalar* d, Scalar* du, Scalar* dlf, Scalar* df,
+           Scalar* duf, Scalar* du2, blas_int* ipiv, Scalar* b, blas_int ldb, Scalar* x, blas_int ldx, Scalar& rcond,
+           Scalar* forward_error, Scalar* backward_error, Scalar* work, blas_int* iwork)
+{
+  blas_int const info = unchecked::gtsvx(fact, trans, n, nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, ldb, x, ldx,
+                                         rcond, forward_error, backward_error, work, iwork);
+  return detail::check_expert_solve("gtsvx", n, info);
+}
+
+} // namespace uni20::lapack

--- a/src/uni20/backend/lapack/reference/band.hpp
+++ b/src/uni20/backend/lapack/reference/band.hpp
@@ -1,0 +1,251 @@
+#pragma once
+
+/**
+ * \file band.hpp
+ * \ingroup backend_lapack_reference
+ * \brief Reference LAPACK wrappers for real general-band linear algebra.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/config.hpp>
+
+namespace uni20::lapack::unchecked
+{
+
+namespace detail
+{
+extern "C"
+{
+  void sgbsv_(blas_int const* n, blas_int const* kl, blas_int const* ku, blas_int const* nrhs, float* ab,
+              blas_int const* ldab, blas_int* ipiv, float* b, blas_int const* ldb, blas_int* info);
+
+  void dgbsv_(blas_int const* n, blas_int const* kl, blas_int const* ku, blas_int const* nrhs, double* ab,
+              blas_int const* ldab, blas_int* ipiv, double* b, blas_int const* ldb, blas_int* info);
+
+  void sgbtrf_(blas_int const* m, blas_int const* n, blas_int const* kl, blas_int const* ku, float* ab,
+               blas_int const* ldab, blas_int* ipiv, blas_int* info);
+
+  void dgbtrf_(blas_int const* m, blas_int const* n, blas_int const* kl, blas_int const* ku, double* ab,
+               blas_int const* ldab, blas_int* ipiv, blas_int* info);
+
+  void sgbtrs_(char const* trans, blas_int const* n, blas_int const* kl, blas_int const* ku, blas_int const* nrhs,
+               float* ab, blas_int const* ldab, blas_int const* ipiv, float* b, blas_int const* ldb, blas_int* info);
+
+  void dgbtrs_(char const* trans, blas_int const* n, blas_int const* kl, blas_int const* ku, blas_int const* nrhs,
+               double* ab, blas_int const* ldab, blas_int const* ipiv, double* b, blas_int const* ldb, blas_int* info);
+
+  void sgbcon_(char const* norm, blas_int const* n, blas_int const* kl, blas_int const* ku, float* ab,
+               blas_int const* ldab, blas_int const* ipiv, float const* anorm, float* rcond, float* work,
+               blas_int* iwork, blas_int* info);
+
+  void dgbcon_(char const* norm, blas_int const* n, blas_int const* kl, blas_int const* ku, double* ab,
+               blas_int const* ldab, blas_int const* ipiv, double const* anorm, double* rcond, double* work,
+               blas_int* iwork, blas_int* info);
+
+  void sgbrfs_(char const* trans, blas_int const* n, blas_int const* kl, blas_int const* ku, blas_int const* nrhs,
+               float* ab, blas_int const* ldab, float* afb, blas_int const* ldafb, blas_int const* ipiv, float* b,
+               blas_int const* ldb, float* x, blas_int const* ldx, float* ferr, float* berr, float* work,
+               blas_int* iwork, blas_int* info);
+
+  void dgbrfs_(char const* trans, blas_int const* n, blas_int const* kl, blas_int const* ku, blas_int const* nrhs,
+               double* ab, blas_int const* ldab, double* afb, blas_int const* ldafb, blas_int const* ipiv, double* b,
+               blas_int const* ldb, double* x, blas_int const* ldx, double* ferr, double* berr, double* work,
+               blas_int* iwork, blas_int* info);
+
+  void sgbsvx_(char const* fact, char const* trans, blas_int const* n, blas_int const* kl, blas_int const* ku,
+               blas_int const* nrhs, float* ab, blas_int const* ldab, float* afb, blas_int const* ldafb, blas_int* ipiv,
+               char* equed, float* row_scale, float* column_scale, float* b, blas_int const* ldb, float* x,
+               blas_int const* ldx, float* rcond, float* ferr, float* berr, float* work, blas_int* iwork,
+               blas_int* info);
+
+  void dgbsvx_(char const* fact, char const* trans, blas_int const* n, blas_int const* kl, blas_int const* ku,
+               blas_int const* nrhs, double* ab, blas_int const* ldab, double* afb, blas_int const* ldafb,
+               blas_int* ipiv, char* equed, double* row_scale, double* column_scale, double* b, blas_int const* ldb,
+               double* x, blas_int const* ldx, double* rcond, double* ferr, double* berr, double* work, blas_int* iwork,
+               blas_int* info);
+
+  void sgbequ_(blas_int const* m, blas_int const* n, blas_int const* kl, blas_int const* ku, float* ab,
+               blas_int const* ldab, float* row_scale, float* column_scale, float* row_condition,
+               float* column_condition, float* max_abs, blas_int* info);
+
+  void dgbequ_(blas_int const* m, blas_int const* n, blas_int const* kl, blas_int const* ku, double* ab,
+               blas_int const* ldab, double* row_scale, double* column_scale, double* row_condition,
+               double* column_condition, double* max_abs, blas_int* info);
+
+  void sgbequb_(blas_int const* m, blas_int const* n, blas_int const* kl, blas_int const* ku, float* ab,
+                blas_int const* ldab, float* row_scale, float* column_scale, float* row_condition,
+                float* column_condition, float* max_abs, blas_int* info);
+
+  void dgbequb_(blas_int const* m, blas_int const* n, blas_int const* kl, blas_int const* ku, double* ab,
+                blas_int const* ldab, double* row_scale, double* column_scale, double* row_condition,
+                double* column_condition, double* max_abs, blas_int* info);
+}
+} // namespace detail
+
+[[nodiscard]] inline blas_int gbsv(blas_int n, blas_int kl, blas_int ku, blas_int nrhs, float* ab, blas_int ldab,
+                                   blas_int* ipiv, float* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgbsv_, n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb);
+  detail::sgbsv_(&n, &kl, &ku, &nrhs, ab, &ldab, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbsv(blas_int n, blas_int kl, blas_int ku, blas_int nrhs, double* ab, blas_int ldab,
+                                   blas_int* ipiv, double* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgbsv_, n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb);
+  detail::dgbsv_(&n, &kl, &ku, &nrhs, ab, &ldab, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbtrf(blas_int m, blas_int n, blas_int kl, blas_int ku, float* ab, blas_int ldab,
+                                    blas_int* ipiv)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgbtrf_, m, n, kl, ku, ab, ldab, ipiv);
+  detail::sgbtrf_(&m, &n, &kl, &ku, ab, &ldab, ipiv, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbtrf(blas_int m, blas_int n, blas_int kl, blas_int ku, double* ab, blas_int ldab,
+                                    blas_int* ipiv)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgbtrf_, m, n, kl, ku, ab, ldab, ipiv);
+  detail::dgbtrf_(&m, &n, &kl, &ku, ab, &ldab, ipiv, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbtrs(char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs, float* ab,
+                                    blas_int ldab, blas_int const* ipiv, float* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgbtrs_, trans, n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb);
+  detail::sgbtrs_(&trans, &n, &kl, &ku, &nrhs, ab, &ldab, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbtrs(char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs, double* ab,
+                                    blas_int ldab, blas_int const* ipiv, double* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgbtrs_, trans, n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb);
+  detail::dgbtrs_(&trans, &n, &kl, &ku, &nrhs, ab, &ldab, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbcon(char norm, blas_int n, blas_int kl, blas_int ku, float* ab, blas_int ldab,
+                                    blas_int const* ipiv, float anorm, float& rcond, float* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgbcon_, norm, n, kl, ku, ab, ldab, ipiv, anorm, work, iwork);
+  detail::sgbcon_(&norm, &n, &kl, &ku, ab, &ldab, ipiv, &anorm, &rcond, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbcon(char norm, blas_int n, blas_int kl, blas_int ku, double* ab, blas_int ldab,
+                                    blas_int const* ipiv, double anorm, double& rcond, double* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgbcon_, norm, n, kl, ku, ab, ldab, ipiv, anorm, work, iwork);
+  detail::dgbcon_(&norm, &n, &kl, &ku, ab, &ldab, ipiv, &anorm, &rcond, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbrfs(char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs, float* ab,
+                                    blas_int ldab, float* afb, blas_int ldafb, blas_int const* ipiv, float* b,
+                                    blas_int ldb, float* x, blas_int ldx, float* forward_error, float* backward_error,
+                                    float* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgbrfs_, trans, n, kl, ku, nrhs, ab, ldab, afb, ldafb, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  detail::sgbrfs_(&trans, &n, &kl, &ku, &nrhs, ab, &ldab, afb, &ldafb, ipiv, b, &ldb, x, &ldx, forward_error,
+                  backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbrfs(char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs, double* ab,
+                                    blas_int ldab, double* afb, blas_int ldafb, blas_int const* ipiv, double* b,
+                                    blas_int ldb, double* x, blas_int ldx, double* forward_error,
+                                    double* backward_error, double* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgbrfs_, trans, n, kl, ku, nrhs, ab, ldab, afb, ldafb, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  detail::dgbrfs_(&trans, &n, &kl, &ku, &nrhs, ab, &ldab, afb, &ldafb, ipiv, b, &ldb, x, &ldx, forward_error,
+                  backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbsvx(char fact, char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs,
+                                    float* ab, blas_int ldab, float* afb, blas_int ldafb, blas_int* ipiv, char& equed,
+                                    float* row_scale, float* column_scale, float* b, blas_int ldb, float* x,
+                                    blas_int ldx, float& rcond, float* forward_error, float* backward_error,
+                                    float* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgbsvx_, fact, trans, n, kl, ku, nrhs, ab, ldab, afb, ldafb, ipiv, equed, row_scale,
+                          column_scale, b, ldb, x, ldx, work, iwork);
+  detail::sgbsvx_(&fact, &trans, &n, &kl, &ku, &nrhs, ab, &ldab, afb, &ldafb, ipiv, &equed, row_scale, column_scale, b,
+                  &ldb, x, &ldx, &rcond, forward_error, backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbsvx(char fact, char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs,
+                                    double* ab, blas_int ldab, double* afb, blas_int ldafb, blas_int* ipiv, char& equed,
+                                    double* row_scale, double* column_scale, double* b, blas_int ldb, double* x,
+                                    blas_int ldx, double& rcond, double* forward_error, double* backward_error,
+                                    double* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgbsvx_, fact, trans, n, kl, ku, nrhs, ab, ldab, afb, ldafb, ipiv, equed, row_scale,
+                          column_scale, b, ldb, x, ldx, work, iwork);
+  detail::dgbsvx_(&fact, &trans, &n, &kl, &ku, &nrhs, ab, &ldab, afb, &ldafb, ipiv, &equed, row_scale, column_scale, b,
+                  &ldb, x, &ldx, &rcond, forward_error, backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbequ(bool power_of_two, blas_int m, blas_int n, blas_int kl, blas_int ku, float* ab,
+                                    blas_int ldab, float* row_scale, float* column_scale, float& row_condition,
+                                    float& column_condition, float& max_abs)
+{
+  blas_int info = 0;
+  if (power_of_two)
+  {
+    UNI20_EXTERNAL_API_CALL(LAPACK, sgbequb_, m, n, kl, ku, ab, ldab, row_scale, column_scale);
+    detail::sgbequb_(&m, &n, &kl, &ku, ab, &ldab, row_scale, column_scale, &row_condition, &column_condition, &max_abs,
+                     &info);
+  }
+  else
+  {
+    UNI20_EXTERNAL_API_CALL(LAPACK, sgbequ_, m, n, kl, ku, ab, ldab, row_scale, column_scale);
+    detail::sgbequ_(&m, &n, &kl, &ku, ab, &ldab, row_scale, column_scale, &row_condition, &column_condition, &max_abs,
+                    &info);
+  }
+  return info;
+}
+
+[[nodiscard]] inline blas_int gbequ(bool power_of_two, blas_int m, blas_int n, blas_int kl, blas_int ku, double* ab,
+                                    blas_int ldab, double* row_scale, double* column_scale, double& row_condition,
+                                    double& column_condition, double& max_abs)
+{
+  blas_int info = 0;
+  if (power_of_two)
+  {
+    UNI20_EXTERNAL_API_CALL(LAPACK, dgbequb_, m, n, kl, ku, ab, ldab, row_scale, column_scale);
+    detail::dgbequb_(&m, &n, &kl, &ku, ab, &ldab, row_scale, column_scale, &row_condition, &column_condition, &max_abs,
+                     &info);
+  }
+  else
+  {
+    UNI20_EXTERNAL_API_CALL(LAPACK, dgbequ_, m, n, kl, ku, ab, ldab, row_scale, column_scale);
+    detail::dgbequ_(&m, &n, &kl, &ku, ab, &ldab, row_scale, column_scale, &row_condition, &column_condition, &max_abs,
+                    &info);
+  }
+  return info;
+}
+
+} // namespace uni20::lapack::unchecked

--- a/src/uni20/backend/lapack/reference/general.hpp
+++ b/src/uni20/backend/lapack/reference/general.hpp
@@ -1,0 +1,337 @@
+#pragma once
+
+/**
+ * \file general.hpp
+ * \ingroup backend_lapack_reference
+ * \brief Reference LAPACK wrappers for real dense general linear systems.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/config.hpp>
+
+namespace uni20::lapack::unchecked
+{
+
+namespace detail
+{
+extern "C"
+{
+  void sgesv_(blas_int const* n, blas_int const* nrhs, float* a, blas_int const* lda, blas_int* ipiv, float* b,
+              blas_int const* ldb, blas_int* info);
+
+  void dgesv_(blas_int const* n, blas_int const* nrhs, double* a, blas_int const* lda, blas_int* ipiv, double* b,
+              blas_int const* ldb, blas_int* info);
+
+  void sgesvx_(char const* fact, char const* trans, blas_int const* n, blas_int const* nrhs, float* a,
+               blas_int const* lda, float* af, blas_int const* ldaf, blas_int* ipiv, char* equed, float* r, float* c,
+               float* b, blas_int const* ldb, float* x, blas_int const* ldx, float* rcond, float* ferr, float* berr,
+               float* work, blas_int* iwork, blas_int* info);
+
+  void dgesvx_(char const* fact, char const* trans, blas_int const* n, blas_int const* nrhs, double* a,
+               blas_int const* lda, double* af, blas_int const* ldaf, blas_int* ipiv, char* equed, double* r, double* c,
+               double* b, blas_int const* ldb, double* x, blas_int const* ldx, double* rcond, double* ferr,
+               double* berr, double* work, blas_int* iwork, blas_int* info);
+
+  void sgeequ_(blas_int const* m, blas_int const* n, float* a, blas_int const* lda, float* r, float* c, float* rowcnd,
+               float* colcnd, float* amax, blas_int* info);
+
+  void dgeequ_(blas_int const* m, blas_int const* n, double* a, blas_int const* lda, double* r, double* c,
+               double* rowcnd, double* colcnd, double* amax, blas_int* info);
+
+  void sgetrf_(blas_int const* m, blas_int const* n, float* a, blas_int const* lda, blas_int* ipiv, blas_int* info);
+
+  void dgetrf_(blas_int const* m, blas_int const* n, double* a, blas_int const* lda, blas_int* ipiv, blas_int* info);
+
+  void sgetrs_(char const* trans, blas_int const* n, blas_int const* nrhs, float* a, blas_int const* lda,
+               blas_int const* ipiv, float* b, blas_int const* ldb, blas_int* info);
+
+  void dgetrs_(char const* trans, blas_int const* n, blas_int const* nrhs, double* a, blas_int const* lda,
+               blas_int const* ipiv, double* b, blas_int const* ldb, blas_int* info);
+
+  void sgerfs_(char const* trans, blas_int const* n, blas_int const* nrhs, float* a, blas_int const* lda, float* af,
+               blas_int const* ldaf, blas_int const* ipiv, float* b, blas_int const* ldb, float* x, blas_int const* ldx,
+               float* ferr, float* berr, float* work, blas_int* iwork, blas_int* info);
+
+  void dgerfs_(char const* trans, blas_int const* n, blas_int const* nrhs, double* a, blas_int const* lda, double* af,
+               blas_int const* ldaf, blas_int const* ipiv, double* b, blas_int const* ldb, double* x,
+               blas_int const* ldx, double* ferr, double* berr, double* work, blas_int* iwork, blas_int* info);
+
+  void sgetri_(blas_int const* n, float* a, blas_int const* lda, blas_int* ipiv, float* work, blas_int const* lwork,
+               blas_int* info);
+
+  void dgetri_(blas_int const* n, double* a, blas_int const* lda, blas_int* ipiv, double* work, blas_int const* lwork,
+               blas_int* info);
+
+  void sgecon_(char const* norm, blas_int const* n, float const* a, blas_int const* lda, float const* anorm,
+               float* rcond, float* work, blas_int* iwork, blas_int* info);
+
+  void dgecon_(char const* norm, blas_int const* n, double const* a, blas_int const* lda, double const* anorm,
+               double* rcond, double* work, blas_int* iwork, blas_int* info);
+
+  void sgels_(char const* trans, blas_int const* m, blas_int const* n, blas_int const* nrhs, float* a,
+              blas_int const* lda, float* b, blas_int const* ldb, float* work, blas_int const* lwork, blas_int* info);
+
+  void dgels_(char const* trans, blas_int const* m, blas_int const* n, blas_int const* nrhs, double* a,
+              blas_int const* lda, double* b, blas_int const* ldb, double* work, blas_int const* lwork, blas_int* info);
+
+  void sgelss_(blas_int const* m, blas_int const* n, blas_int const* nrhs, float* a, blas_int const* lda, float* b,
+               blas_int const* ldb, float* s, float const* rcond, blas_int* rank, float* work, blas_int const* lwork,
+               blas_int* info);
+
+  void dgelss_(blas_int const* m, blas_int const* n, blas_int const* nrhs, double* a, blas_int const* lda, double* b,
+               blas_int const* ldb, double* s, double const* rcond, blas_int* rank, double* work, blas_int const* lwork,
+               blas_int* info);
+
+  void sgelsd_(blas_int const* m, blas_int const* n, blas_int const* nrhs, float* a, blas_int const* lda, float* b,
+               blas_int const* ldb, float* s, float const* rcond, blas_int* rank, float* work, blas_int const* lwork,
+               blas_int* iwork, blas_int* info);
+
+  void dgelsd_(blas_int const* m, blas_int const* n, blas_int const* nrhs, double* a, blas_int const* lda, double* b,
+               blas_int const* ldb, double* s, double const* rcond, blas_int* rank, double* work, blas_int const* lwork,
+               blas_int* iwork, blas_int* info);
+
+  void sgelsy_(blas_int const* m, blas_int const* n, blas_int const* nrhs, float* a, blas_int const* lda, float* b,
+               blas_int const* ldb, blas_int* jpvt, float const* rcond, blas_int* rank, float* work,
+               blas_int const* lwork, blas_int* info);
+
+  void dgelsy_(blas_int const* m, blas_int const* n, blas_int const* nrhs, double* a, blas_int const* lda, double* b,
+               blas_int const* ldb, blas_int* jpvt, double const* rcond, blas_int* rank, double* work,
+               blas_int const* lwork, blas_int* info);
+}
+} // namespace detail
+
+[[nodiscard]] inline blas_int gesv(blas_int n, blas_int nrhs, float* a, blas_int lda, blas_int* ipiv, float* b,
+                                   blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgesv_, n, nrhs, a, lda, ipiv, b, ldb);
+  detail::sgesv_(&n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gesv(blas_int n, blas_int nrhs, double* a, blas_int lda, blas_int* ipiv, double* b,
+                                   blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgesv_, n, nrhs, a, lda, ipiv, b, ldb);
+  detail::dgesv_(&n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gesvx(char fact, char trans, blas_int n, blas_int nrhs, float* a, blas_int lda, float* af,
+                                    blas_int ldaf, blas_int* ipiv, char& equed, float* row_scale, float* column_scale,
+                                    float* b, blas_int ldb, float* x, blas_int ldx, float& rcond, float* forward_error,
+                                    float* backward_error, float* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgesvx_, fact, trans, n, nrhs, a, lda, af, ldaf, ipiv, equed, row_scale, column_scale,
+                          b, ldb, x, ldx, work, iwork);
+  detail::sgesvx_(&fact, &trans, &n, &nrhs, a, &lda, af, &ldaf, ipiv, &equed, row_scale, column_scale, b, &ldb, x, &ldx,
+                  &rcond, forward_error, backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gesvx(char fact, char trans, blas_int n, blas_int nrhs, double* a, blas_int lda,
+                                    double* af, blas_int ldaf, blas_int* ipiv, char& equed, double* row_scale,
+                                    double* column_scale, double* b, blas_int ldb, double* x, blas_int ldx,
+                                    double& rcond, double* forward_error, double* backward_error, double* work,
+                                    blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgesvx_, fact, trans, n, nrhs, a, lda, af, ldaf, ipiv, equed, row_scale, column_scale,
+                          b, ldb, x, ldx, work, iwork);
+  detail::dgesvx_(&fact, &trans, &n, &nrhs, a, &lda, af, &ldaf, ipiv, &equed, row_scale, column_scale, b, &ldb, x, &ldx,
+                  &rcond, forward_error, backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int geequ(blas_int m, blas_int n, float* a, blas_int lda, float* row_scale,
+                                    float* column_scale, float& row_condition, float& column_condition, float& max_abs)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgeequ_, m, n, a, lda, row_scale, column_scale);
+  detail::sgeequ_(&m, &n, a, &lda, row_scale, column_scale, &row_condition, &column_condition, &max_abs, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int geequ(blas_int m, blas_int n, double* a, blas_int lda, double* row_scale,
+                                    double* column_scale, double& row_condition, double& column_condition,
+                                    double& max_abs)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgeequ_, m, n, a, lda, row_scale, column_scale);
+  detail::dgeequ_(&m, &n, a, &lda, row_scale, column_scale, &row_condition, &column_condition, &max_abs, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int getrf(blas_int m, blas_int n, float* a, blas_int lda, blas_int* ipiv)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgetrf_, m, n, a, lda, ipiv);
+  detail::sgetrf_(&m, &n, a, &lda, ipiv, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int getrf(blas_int m, blas_int n, double* a, blas_int lda, blas_int* ipiv)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgetrf_, m, n, a, lda, ipiv);
+  detail::dgetrf_(&m, &n, a, &lda, ipiv, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int getrs(char trans, blas_int n, blas_int nrhs, float* a, blas_int lda, blas_int const* ipiv,
+                                    float* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgetrs_, trans, n, nrhs, a, lda, ipiv, b, ldb);
+  detail::sgetrs_(&trans, &n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int getrs(char trans, blas_int n, blas_int nrhs, double* a, blas_int lda,
+                                    blas_int const* ipiv, double* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgetrs_, trans, n, nrhs, a, lda, ipiv, b, ldb);
+  detail::dgetrs_(&trans, &n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gerfs(char trans, blas_int n, blas_int nrhs, float* a, blas_int lda, float* factors,
+                                    blas_int factor_lda, blas_int const* ipiv, float* b, blas_int ldb, float* x,
+                                    blas_int ldx, float* forward_error, float* backward_error, float* work,
+                                    blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgerfs_, trans, n, nrhs, a, lda, factors, factor_lda, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  detail::sgerfs_(&trans, &n, &nrhs, a, &lda, factors, &factor_lda, ipiv, b, &ldb, x, &ldx, forward_error,
+                  backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gerfs(char trans, blas_int n, blas_int nrhs, double* a, blas_int lda, double* factors,
+                                    blas_int factor_lda, blas_int const* ipiv, double* b, blas_int ldb, double* x,
+                                    blas_int ldx, double* forward_error, double* backward_error, double* work,
+                                    blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgerfs_, trans, n, nrhs, a, lda, factors, factor_lda, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  detail::dgerfs_(&trans, &n, &nrhs, a, &lda, factors, &factor_lda, ipiv, b, &ldb, x, &ldx, forward_error,
+                  backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int getri(blas_int n, float* a, blas_int lda, blas_int* ipiv, float* work, blas_int lwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgetri_, n, a, lda, ipiv, work, lwork);
+  detail::sgetri_(&n, a, &lda, ipiv, work, &lwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int getri(blas_int n, double* a, blas_int lda, blas_int* ipiv, double* work, blas_int lwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgetri_, n, a, lda, ipiv, work, lwork);
+  detail::dgetri_(&n, a, &lda, ipiv, work, &lwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gecon(char norm, blas_int n, float const* a, blas_int lda, float anorm, float& rcond,
+                                    float* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgecon_, norm, n, a, lda, anorm, work, iwork);
+  detail::sgecon_(&norm, &n, a, &lda, &anorm, &rcond, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gecon(char norm, blas_int n, double const* a, blas_int lda, double anorm, double& rcond,
+                                    double* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgecon_, norm, n, a, lda, anorm, work, iwork);
+  detail::dgecon_(&norm, &n, a, &lda, &anorm, &rcond, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gels(char trans, blas_int m, blas_int n, blas_int nrhs, float* a, blas_int lda, float* b,
+                                   blas_int ldb, float* work, blas_int lwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgels_, trans, m, n, nrhs, a, lda, b, ldb, work, lwork);
+  detail::sgels_(&trans, &m, &n, &nrhs, a, &lda, b, &ldb, work, &lwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gels(char trans, blas_int m, blas_int n, blas_int nrhs, double* a, blas_int lda,
+                                   double* b, blas_int ldb, double* work, blas_int lwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgels_, trans, m, n, nrhs, a, lda, b, ldb, work, lwork);
+  detail::dgels_(&trans, &m, &n, &nrhs, a, &lda, b, &ldb, work, &lwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gelss(blas_int m, blas_int n, blas_int nrhs, float* a, blas_int lda, float* b,
+                                    blas_int ldb, float* s, float rcond, blas_int& rank, float* work, blas_int lwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgelss_, m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork);
+  detail::sgelss_(&m, &n, &nrhs, a, &lda, b, &ldb, s, &rcond, &rank, work, &lwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gelss(blas_int m, blas_int n, blas_int nrhs, double* a, blas_int lda, double* b,
+                                    blas_int ldb, double* s, double rcond, blas_int& rank, double* work, blas_int lwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgelss_, m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork);
+  detail::dgelss_(&m, &n, &nrhs, a, &lda, b, &ldb, s, &rcond, &rank, work, &lwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gelsd(blas_int m, blas_int n, blas_int nrhs, float* a, blas_int lda, float* b,
+                                    blas_int ldb, float* s, float rcond, blas_int& rank, float* work, blas_int lwork,
+                                    blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgelsd_, m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, iwork);
+  detail::sgelsd_(&m, &n, &nrhs, a, &lda, b, &ldb, s, &rcond, &rank, work, &lwork, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gelsd(blas_int m, blas_int n, blas_int nrhs, double* a, blas_int lda, double* b,
+                                    blas_int ldb, double* s, double rcond, blas_int& rank, double* work, blas_int lwork,
+                                    blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgelsd_, m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, iwork);
+  detail::dgelsd_(&m, &n, &nrhs, a, &lda, b, &ldb, s, &rcond, &rank, work, &lwork, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gelsy(blas_int m, blas_int n, blas_int nrhs, float* a, blas_int lda, float* b,
+                                    blas_int ldb, blas_int* jpvt, float rcond, blas_int& rank, float* work,
+                                    blas_int lwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgelsy_, m, n, nrhs, a, lda, b, ldb, jpvt, rcond, rank, work, lwork);
+  detail::sgelsy_(&m, &n, &nrhs, a, &lda, b, &ldb, jpvt, &rcond, &rank, work, &lwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gelsy(blas_int m, blas_int n, blas_int nrhs, double* a, blas_int lda, double* b,
+                                    blas_int ldb, blas_int* jpvt, double rcond, blas_int& rank, double* work,
+                                    blas_int lwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgelsy_, m, n, nrhs, a, lda, b, ldb, jpvt, rcond, rank, work, lwork);
+  detail::dgelsy_(&m, &n, &nrhs, a, &lda, b, &ldb, jpvt, &rcond, &rank, work, &lwork, &info);
+  return info;
+}
+
+} // namespace uni20::lapack::unchecked

--- a/src/uni20/backend/lapack/reference/norms.hpp
+++ b/src/uni20/backend/lapack/reference/norms.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+/**
+ * \defgroup backend_lapack_reference Reference LAPACK backend
+ * \ingroup backend_lapack
+ * \brief Header-only wrappers around the configured float/double LAPACK library.
+ */
+
+/**
+ * \file norms.hpp
+ * \ingroup backend_lapack_reference
+ * \brief LAPACK norm wrappers for the reference float/double backend.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/config.hpp>
+
+namespace uni20::lapack::unchecked
+{
+
+namespace detail
+{
+extern "C"
+{
+  float slange_(char const* norm, blas_int const* m, blas_int const* n, float* a, blas_int const* lda, float* work);
+
+  double dlange_(char const* norm, blas_int const* m, blas_int const* n, double* a, blas_int const* lda, double* work);
+
+  float slansy_(char const* norm, char const* uplo, blas_int const* n, float* a, blas_int const* lda, float* work);
+
+  double dlansy_(char const* norm, char const* uplo, blas_int const* n, double* a, blas_int const* lda, double* work);
+
+  float slantr_(char const* norm, char const* uplo, char const* diag, blas_int const* m, blas_int const* n, float* a,
+                blas_int const* lda, float* work);
+
+  double dlantr_(char const* norm, char const* uplo, char const* diag, blas_int const* m, blas_int const* n, double* a,
+                 blas_int const* lda, double* work);
+
+  float slangb_(char const* norm, blas_int const* n, blas_int const* kl, blas_int const* ku, float* ab,
+                blas_int const* ldab, float* work);
+
+  double dlangb_(char const* norm, blas_int const* n, blas_int const* kl, blas_int const* ku, double* ab,
+                 blas_int const* ldab, double* work);
+}
+} // namespace detail
+
+[[nodiscard]] inline float lange(char norm, blas_int m, blas_int n, float* a, blas_int lda, float* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, slange_, norm, m, n, a, lda, work);
+  return detail::slange_(&norm, &m, &n, a, &lda, work);
+}
+
+[[nodiscard]] inline double lange(char norm, blas_int m, blas_int n, double* a, blas_int lda, double* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, dlange_, norm, m, n, a, lda, work);
+  return detail::dlange_(&norm, &m, &n, a, &lda, work);
+}
+
+[[nodiscard]] inline float lansy(char norm, char uplo, blas_int n, float* a, blas_int lda, float* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, slansy_, norm, uplo, n, a, lda, work);
+  return detail::slansy_(&norm, &uplo, &n, a, &lda, work);
+}
+
+[[nodiscard]] inline double lansy(char norm, char uplo, blas_int n, double* a, blas_int lda, double* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, dlansy_, norm, uplo, n, a, lda, work);
+  return detail::dlansy_(&norm, &uplo, &n, a, &lda, work);
+}
+
+[[nodiscard]] inline float lantr(char norm, char uplo, char diag, blas_int m, blas_int n, float* a, blas_int lda,
+                                 float* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, slantr_, norm, uplo, diag, m, n, a, lda, work);
+  return detail::slantr_(&norm, &uplo, &diag, &m, &n, a, &lda, work);
+}
+
+[[nodiscard]] inline double lantr(char norm, char uplo, char diag, blas_int m, blas_int n, double* a, blas_int lda,
+                                  double* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, dlantr_, norm, uplo, diag, m, n, a, lda, work);
+  return detail::dlantr_(&norm, &uplo, &diag, &m, &n, a, &lda, work);
+}
+
+[[nodiscard]] inline float langb(char norm, blas_int n, blas_int kl, blas_int ku, float* ab, blas_int ldab, float* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, slangb_, norm, n, kl, ku, ab, ldab, work);
+  return detail::slangb_(&norm, &n, &kl, &ku, ab, &ldab, work);
+}
+
+[[nodiscard]] inline double langb(char norm, blas_int n, blas_int kl, blas_int ku, double* ab, blas_int ldab,
+                                  double* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, dlangb_, norm, n, kl, ku, ab, ldab, work);
+  return detail::dlangb_(&norm, &n, &kl, &ku, ab, &ldab, work);
+}
+
+} // namespace uni20::lapack::unchecked

--- a/src/uni20/backend/lapack/reference/tridiagonal.hpp
+++ b/src/uni20/backend/lapack/reference/tridiagonal.hpp
@@ -1,0 +1,184 @@
+#pragma once
+
+/**
+ * \file tridiagonal.hpp
+ * \ingroup backend_lapack_reference
+ * \brief Reference LAPACK wrappers for real tridiagonal linear algebra.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/config.hpp>
+
+namespace uni20::lapack::unchecked
+{
+
+namespace detail
+{
+extern "C"
+{
+  void sgtsv_(blas_int const* n, blas_int const* nrhs, float* dl, float* d, float* du, float* b, blas_int const* ldb,
+              blas_int* info);
+
+  void dgtsv_(blas_int const* n, blas_int const* nrhs, double* dl, double* d, double* du, double* b,
+              blas_int const* ldb, blas_int* info);
+
+  void sgttrf_(blas_int const* n, float* dl, float* d, float* du, float* du2, blas_int* ipiv, blas_int* info);
+
+  void dgttrf_(blas_int const* n, double* dl, double* d, double* du, double* du2, blas_int* ipiv, blas_int* info);
+
+  void sgttrs_(char const* trans, blas_int const* n, blas_int const* nrhs, float* dl, float* d, float* du, float* du2,
+               blas_int const* ipiv, float* b, blas_int const* ldb, blas_int* info);
+
+  void dgttrs_(char const* trans, blas_int const* n, blas_int const* nrhs, double* dl, double* d, double* du,
+               double* du2, blas_int const* ipiv, double* b, blas_int const* ldb, blas_int* info);
+
+  void sgtcon_(char const* norm, blas_int const* n, float* dl, float* d, float* du, float* du2, blas_int const* ipiv,
+               float const* anorm, float* rcond, float* work, blas_int* iwork, blas_int* info);
+
+  void dgtcon_(char const* norm, blas_int const* n, double* dl, double* d, double* du, double* du2,
+               blas_int const* ipiv, double const* anorm, double* rcond, double* work, blas_int* iwork, blas_int* info);
+
+  void sgtrfs_(char const* trans, blas_int const* n, blas_int const* nrhs, float* dl, float* d, float* du, float* dlf,
+               float* df, float* duf, float* du2, blas_int const* ipiv, float* b, blas_int const* ldb, float* x,
+               blas_int const* ldx, float* ferr, float* berr, float* work, blas_int* iwork, blas_int* info);
+
+  void dgtrfs_(char const* trans, blas_int const* n, blas_int const* nrhs, double* dl, double* d, double* du,
+               double* dlf, double* df, double* duf, double* du2, blas_int const* ipiv, double* b, blas_int const* ldb,
+               double* x, blas_int const* ldx, double* ferr, double* berr, double* work, blas_int* iwork,
+               blas_int* info);
+
+  void sgtsvx_(char const* fact, char const* trans, blas_int const* n, blas_int const* nrhs, float* dl, float* d,
+               float* du, float* dlf, float* df, float* duf, float* du2, blas_int* ipiv, float* b, blas_int const* ldb,
+               float* x, blas_int const* ldx, float* rcond, float* ferr, float* berr, float* work, blas_int* iwork,
+               blas_int* info);
+
+  void dgtsvx_(char const* fact, char const* trans, blas_int const* n, blas_int const* nrhs, double* dl, double* d,
+               double* du, double* dlf, double* df, double* duf, double* du2, blas_int* ipiv, double* b,
+               blas_int const* ldb, double* x, blas_int const* ldx, double* rcond, double* ferr, double* berr,
+               double* work, blas_int* iwork, blas_int* info);
+}
+} // namespace detail
+
+[[nodiscard]] inline blas_int gtsv(blas_int n, blas_int nrhs, float* dl, float* d, float* du, float* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgtsv_, n, nrhs, dl, d, du, b, ldb);
+  detail::sgtsv_(&n, &nrhs, dl, d, du, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gtsv(blas_int n, blas_int nrhs, double* dl, double* d, double* du, double* b,
+                                   blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgtsv_, n, nrhs, dl, d, du, b, ldb);
+  detail::dgtsv_(&n, &nrhs, dl, d, du, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gttrf(blas_int n, float* dl, float* d, float* du, float* du2, blas_int* ipiv)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgttrf_, n, dl, d, du, du2, ipiv);
+  detail::sgttrf_(&n, dl, d, du, du2, ipiv, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gttrf(blas_int n, double* dl, double* d, double* du, double* du2, blas_int* ipiv)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgttrf_, n, dl, d, du, du2, ipiv);
+  detail::dgttrf_(&n, dl, d, du, du2, ipiv, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gttrs(char trans, blas_int n, blas_int nrhs, float* dl, float* d, float* du, float* du2,
+                                    blas_int const* ipiv, float* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgttrs_, trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb);
+  detail::sgttrs_(&trans, &n, &nrhs, dl, d, du, du2, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gttrs(char trans, blas_int n, blas_int nrhs, double* dl, double* d, double* du,
+                                    double* du2, blas_int const* ipiv, double* b, blas_int ldb)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgttrs_, trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb);
+  detail::dgttrs_(&trans, &n, &nrhs, dl, d, du, du2, ipiv, b, &ldb, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gtcon(char norm, blas_int n, float* dl, float* d, float* du, float* du2,
+                                    blas_int const* ipiv, float matrix_norm, float& rcond, float* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgtcon_, norm, n, dl, d, du, du2, ipiv, matrix_norm, work, iwork);
+  detail::sgtcon_(&norm, &n, dl, d, du, du2, ipiv, &matrix_norm, &rcond, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gtcon(char norm, blas_int n, double* dl, double* d, double* du, double* du2,
+                                    blas_int const* ipiv, double matrix_norm, double& rcond, double* work,
+                                    blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgtcon_, norm, n, dl, d, du, du2, ipiv, matrix_norm, work, iwork);
+  detail::dgtcon_(&norm, &n, dl, d, du, du2, ipiv, &matrix_norm, &rcond, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gtrfs(char trans, blas_int n, blas_int nrhs, float* dl, float* d, float* du, float* dlf,
+                                    float* df, float* duf, float* du2, blas_int const* ipiv, float* b, blas_int ldb,
+                                    float* x, blas_int ldx, float* forward_error, float* backward_error, float* work,
+                                    blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgtrfs_, trans, n, nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  detail::sgtrfs_(&trans, &n, &nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, &ldb, x, &ldx, forward_error,
+                  backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gtrfs(char trans, blas_int n, blas_int nrhs, double* dl, double* d, double* du,
+                                    double* dlf, double* df, double* duf, double* du2, blas_int const* ipiv, double* b,
+                                    blas_int ldb, double* x, blas_int ldx, double* forward_error,
+                                    double* backward_error, double* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgtrfs_, trans, n, nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  detail::dgtrfs_(&trans, &n, &nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, &ldb, x, &ldx, forward_error,
+                  backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gtsvx(char fact, char trans, blas_int n, blas_int nrhs, float* dl, float* d, float* du,
+                                    float* dlf, float* df, float* duf, float* du2, blas_int* ipiv, float* b,
+                                    blas_int ldb, float* x, blas_int ldx, float& rcond, float* forward_error,
+                                    float* backward_error, float* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, sgtsvx_, fact, trans, n, nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, ldb, x, ldx,
+                          work, iwork);
+  detail::sgtsvx_(&fact, &trans, &n, &nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, &ldb, x, &ldx, &rcond, forward_error,
+                  backward_error, work, iwork, &info);
+  return info;
+}
+
+[[nodiscard]] inline blas_int gtsvx(char fact, char trans, blas_int n, blas_int nrhs, double* dl, double* d, double* du,
+                                    double* dlf, double* df, double* duf, double* du2, blas_int* ipiv, double* b,
+                                    blas_int ldb, double* x, blas_int ldx, double& rcond, double* forward_error,
+                                    double* backward_error, double* work, blas_int* iwork)
+{
+  blas_int info = 0;
+  UNI20_EXTERNAL_API_CALL(LAPACK, dgtsvx_, fact, trans, n, nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, ldb, x, ldx,
+                          work, iwork);
+  detail::dgtsvx_(&fact, &trans, &n, &nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, &ldb, x, &ldx, &rcond, forward_error,
+                  backward_error, work, iwork, &info);
+  return info;
+}
+
+} // namespace uni20::lapack::unchecked

--- a/src/uni20/linalg/CMakeLists.txt
+++ b/src/uni20/linalg/CMakeLists.txt
@@ -1,12 +1,14 @@
-add_library(uni20_linalg INTERFACE)
+add_library(uni20_linalg STATIC
+    backends/cpu/matrix_exponential.cpp
+)
 
 target_include_directories(uni20_linalg
-    INTERFACE
+    PUBLIC
         ${PROJECT_SOURCE_DIR}/src
 )
 
 target_link_libraries(uni20_linalg
-    INTERFACE
+    PUBLIC
         uni20_core
         uni20_common
 )

--- a/src/uni20/linalg/backends/cpu/dense_matrix.hpp
+++ b/src/uni20/linalg/backends/cpu/dense_matrix.hpp
@@ -1,0 +1,333 @@
+#pragma once
+
+#include <uni20/core/scalar_traits.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace uni20::linalg::backends::cpu
+{
+
+/// \brief Minimal column-major dense matrix implementation used by the CPU dense linear algebra routines.
+/// \tparam T Element type stored in the matrix.
+template <typename T> class DenseMatrix {
+  public:
+    DenseMatrix() = default;
+
+    DenseMatrix(std::size_t rows, std::size_t cols) : rows_(rows), cols_(cols), data_(rows * cols) {}
+
+    [[nodiscard]] std::size_t rows() const noexcept { return rows_; }
+
+    [[nodiscard]] std::size_t cols() const noexcept { return cols_; }
+
+    [[nodiscard]] std::size_t size() const noexcept { return data_.size(); }
+
+    T& operator()(std::size_t row, std::size_t col) { return data_[row + col * rows_]; }
+
+    T const& operator()(std::size_t row, std::size_t col) const { return data_[row + col * rows_]; }
+
+    [[nodiscard]] T* data() noexcept { return data_.data(); }
+
+    [[nodiscard]] T const* data() const noexcept { return data_.data(); }
+
+    void swap(DenseMatrix& other) noexcept
+    {
+      std::swap(rows_, other.rows_);
+      std::swap(cols_, other.cols_);
+      data_.swap(other.data_);
+    }
+
+  private:
+    std::size_t rows_ = 0;
+    std::size_t cols_ = 0;
+    std::vector<T> data_;
+};
+
+/// \brief Create an identity matrix of size \p n.
+/// \tparam T Element type used for the identity matrix.
+/// \param n Dimension of the matrix.
+/// \return An \p n-by-\p n identity matrix.
+template <typename T> DenseMatrix<T> make_identity(std::size_t n)
+{
+  DenseMatrix<T> result(n, n);
+  for (std::size_t i = 0; i < n; ++i)
+  {
+    for (std::size_t j = 0; j < n; ++j)
+    {
+      result(i, j) = (i == j) ? T{1} : T{};
+    }
+  }
+  return result;
+}
+
+/// \brief Multiply matrix \p lhs by matrix \p rhs.
+/// \tparam T Element type of the matrices.
+/// \param lhs Left-hand operand.
+/// \param rhs Right-hand operand.
+/// \return The matrix product \p lhs * \p rhs.
+template <typename T> DenseMatrix<T> multiply(DenseMatrix<T> const& lhs, DenseMatrix<T> const& rhs)
+{
+  if (lhs.cols() != rhs.rows())
+  {
+    throw std::invalid_argument("matrix dimensions do not agree for multiplication");
+  }
+
+  DenseMatrix<T> result(lhs.rows(), rhs.cols());
+  for (std::size_t i = 0; i < lhs.rows(); ++i)
+  {
+    for (std::size_t k = 0; k < lhs.cols(); ++k)
+    {
+      T const factor = lhs(i, k);
+      if (factor == T{})
+      {
+        continue;
+      }
+      for (std::size_t j = 0; j < rhs.cols(); ++j)
+      {
+        result(i, j) += factor * rhs(k, j);
+      }
+    }
+  }
+  return result;
+}
+
+/// \brief Add matrices \p lhs and \p rhs.
+/// \tparam T Element type of the matrices.
+/// \param lhs Left-hand operand.
+/// \param rhs Right-hand operand.
+/// \return The element-wise sum of \p lhs and \p rhs.
+template <typename T> DenseMatrix<T> add(DenseMatrix<T> const& lhs, DenseMatrix<T> const& rhs)
+{
+  if (lhs.rows() != rhs.rows() || lhs.cols() != rhs.cols())
+  {
+    throw std::invalid_argument("matrix dimensions do not agree for addition");
+  }
+
+  DenseMatrix<T> result(lhs.rows(), lhs.cols());
+  for (std::size_t i = 0; i < lhs.size(); ++i)
+  {
+    result.data()[i] = lhs.data()[i] + rhs.data()[i];
+  }
+  return result;
+}
+
+/// \brief Subtract matrix \p rhs from \p lhs.
+/// \tparam T Element type of the matrices.
+/// \param lhs Left-hand operand.
+/// \param rhs Right-hand operand.
+/// \return The element-wise difference of \p lhs and \p rhs.
+template <typename T> DenseMatrix<T> subtract(DenseMatrix<T> const& lhs, DenseMatrix<T> const& rhs)
+{
+  if (lhs.rows() != rhs.rows() || lhs.cols() != rhs.cols())
+  {
+    throw std::invalid_argument("matrix dimensions do not agree for subtraction");
+  }
+
+  DenseMatrix<T> result(lhs.rows(), lhs.cols());
+  for (std::size_t i = 0; i < lhs.size(); ++i)
+  {
+    result.data()[i] = lhs.data()[i] - rhs.data()[i];
+  }
+  return result;
+}
+
+/// \brief Multiply matrix \p mat by scalar \p scalar.
+/// \tparam T Element type of the matrix.
+/// \param mat DenseMatrix to scale.
+/// \param scalar Scalar factor.
+/// \return A matrix where each element is \p mat(i, j) * \p scalar.
+template <typename T, typename Scalar> DenseMatrix<T> scale(DenseMatrix<T> const& mat, Scalar const& scalar)
+{
+  DenseMatrix<T> result(mat.rows(), mat.cols());
+  for (std::size_t i = 0; i < mat.size(); ++i)
+  {
+    result.data()[i] = mat.data()[i] * scalar;
+  }
+  return result;
+}
+
+/// \brief Multiply an owned matrix by scalar \p scalar, reusing the existing storage.
+/// \tparam T Element type of the matrix.
+/// \tparam Scalar Scalar factor type.
+/// \param mat Owned DenseMatrix to scale.
+/// \param scalar Scalar factor.
+/// \return The scaled matrix, moved from \p mat.
+template <typename T, typename Scalar> DenseMatrix<T> scale(DenseMatrix<T>&& mat, Scalar const& scalar)
+{
+  for (std::size_t i = 0; i < mat.size(); ++i)
+  {
+    mat.data()[i] *= scalar;
+  }
+  return std::move(mat);
+}
+
+/// \brief Compute the 1-norm (maximum absolute column sum) of a matrix.
+/// \tparam T Element type of the matrix.
+/// \param mat Input matrix.
+/// \return The induced matrix 1-norm of \p mat.
+template <typename T> uni20::accumulation_real_t<T> matrix_one_norm(DenseMatrix<T> const& mat)
+{
+  using Real = uni20::accumulation_real_t<T>;
+  using std::abs;
+
+  Real result = Real{};
+  for (std::size_t j = 0; j < mat.cols(); ++j)
+  {
+    Real column_sum = Real{};
+    for (std::size_t i = 0; i < mat.rows(); ++i)
+    {
+      column_sum += abs(mat(i, j));
+    }
+    result = std::max(result, column_sum);
+  }
+  return result;
+}
+
+/// \brief Raise a square matrix to an integer power.
+/// \tparam T Element type of the matrix.
+/// \param mat Input matrix to be exponentiated.
+/// \param power Non-negative integer exponent.
+/// \return DenseMatrix power \f$mat^{\text{power}}\f$.
+/// \throws std::invalid_argument if \p mat is not square.
+template <typename T> DenseMatrix<T> matrix_power(DenseMatrix<T> const& mat, unsigned int power)
+{
+  if (mat.rows() != mat.cols())
+  {
+    throw std::invalid_argument("matrix_power requires a square matrix");
+  }
+
+  if (power == 0U)
+  {
+    return make_identity<T>(mat.rows());
+  }
+
+  DenseMatrix<T> result = make_identity<T>(mat.rows());
+  DenseMatrix<T> base = mat;
+  unsigned int exponent = power;
+  while (exponent > 0U)
+  {
+    if ((exponent & 1U) != 0U)
+    {
+      result = multiply(result, base);
+    }
+    exponent >>= 1U;
+    if (exponent != 0U)
+    {
+      base = multiply(base, base);
+    }
+  }
+
+  return result;
+}
+
+/// \brief Compute the matrix 1-norm of a matrix power.
+/// \tparam T Element type of the matrix.
+/// \param mat Input matrix.
+/// \param power Non-negative integer exponent.
+/// \return The 1-norm of \f$mat^{\text{power}}\f$.
+template <typename T> uni20::accumulation_real_t<T> matrix_one_norm_power(DenseMatrix<T> const& mat, unsigned int power)
+{
+  DenseMatrix<T> powered = matrix_power(mat, power);
+  return matrix_one_norm(powered);
+}
+
+/// \brief Swap two rows in a matrix.
+/// \tparam T Element type of the matrix.
+/// \param mat DenseMatrix whose rows will be swapped.
+/// \param lhs First row index.
+/// \param rhs Second row index.
+template <typename T> void swap_rows(DenseMatrix<T>& mat, std::size_t lhs, std::size_t rhs)
+{
+  if (lhs == rhs)
+  {
+    return;
+  }
+  for (std::size_t j = 0; j < mat.cols(); ++j)
+  {
+    std::swap(mat(lhs, j), mat(rhs, j));
+  }
+}
+
+/// \brief Solve the linear system A * X = B using Gaussian elimination with partial pivoting.
+/// \tparam T Element type.
+/// \param A Coefficient matrix copied or moved into the solver and overwritten during elimination.
+/// \param B Right-hand side matrix copied or moved into the solver and overwritten during elimination.
+/// \return Solution matrix X satisfying A * X = B.
+/// \throws std::runtime_error if the system is singular.
+template <typename T> DenseMatrix<T> solve_linear_system(DenseMatrix<T> A, DenseMatrix<T> B)
+{
+  if (A.rows() != A.cols() || A.rows() != B.rows())
+  {
+    throw std::invalid_argument("solve_linear_system requires square coefficient matrix");
+  }
+
+  std::size_t n = A.rows();
+  std::size_t nrhs = B.cols();
+  using Real = uni20::accumulation_real_t<T>;
+  using std::abs;
+
+  for (std::size_t k = 0; k < n; ++k)
+  {
+    std::size_t pivot_row = k;
+    Real pivot_value = abs(A(k, k));
+    for (std::size_t i = k + 1; i < n; ++i)
+    {
+      Real candidate = abs(A(i, k));
+      if (candidate > pivot_value)
+      {
+        pivot_value = candidate;
+        pivot_row = i;
+      }
+    }
+
+    if (pivot_value == Real{})
+    {
+      throw std::runtime_error("singular matrix in solve_linear_system");
+    }
+
+    swap_rows(A, k, pivot_row);
+    swap_rows(B, k, pivot_row);
+
+    T const pivot = A(k, k);
+    for (std::size_t i = k + 1; i < n; ++i)
+    {
+      T const factor = A(i, k) / pivot;
+      if (factor == T{})
+      {
+        continue;
+      }
+      A(i, k) = T{};
+      for (std::size_t j = k + 1; j < n; ++j)
+      {
+        A(i, j) -= factor * A(k, j);
+      }
+      for (std::size_t j = 0; j < nrhs; ++j)
+      {
+        B(i, j) -= factor * B(k, j);
+      }
+    }
+  }
+
+  for (std::size_t i = n; i-- > 0;)
+  {
+    T const pivot = A(i, i);
+    for (std::size_t j = 0; j < nrhs; ++j)
+    {
+      T value = B(i, j);
+      for (std::size_t k = i + 1; k < n; ++k)
+      {
+        value -= A(i, k) * B(k, j);
+      }
+      B(i, j) = value / pivot;
+    }
+  }
+
+  return B;
+}
+
+} // namespace uni20::linalg::backends::cpu

--- a/src/uni20/linalg/backends/cpu/linalg_cpu.hpp
+++ b/src/uni20/linalg/backends/cpu/linalg_cpu.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "matrix_exponential.hpp"
 #include "matrix_ops_cpu.hpp"
 
 namespace uni20::linalg::backends::cpu

--- a/src/uni20/linalg/backends/cpu/matrix_exponential.cpp
+++ b/src/uni20/linalg/backends/cpu/matrix_exponential.cpp
@@ -1,0 +1,607 @@
+#include <uni20/linalg/backends/cpu/dense_matrix.hpp>
+#include <uni20/linalg/backends/cpu/matrix_exponential.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <initializer_list>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace uni20::linalg::backends::cpu
+{
+namespace detail
+{
+
+constexpr std::array<double, 5> kThetaBounds{
+    1.495585217958292e-2, // theta_3
+    2.539398330063230e-1, // theta_5
+    9.504178996162932e-1, // theta_7
+    2.097847961257068,    // theta_9
+    5.371920351148152     // theta_13
+};
+
+template <typename Scalar, typename Integer> constexpr Scalar exact_integer(Integer value)
+{
+  return static_cast<Scalar>(value);
+}
+
+template <typename T> auto adl_abs(T const& value)
+{
+  using std::abs;
+  return abs(value);
+}
+
+template <typename T> auto adl_sqrt(T const& value)
+{
+  using std::sqrt;
+  return sqrt(value);
+}
+
+template <typename T> auto adl_log2(T const& value)
+{
+  using std::log2;
+  return log2(value);
+}
+
+template <typename T, typename Exponent> auto adl_pow(T const& value, Exponent const& exponent)
+{
+  using std::pow;
+  return pow(value, exponent);
+}
+
+template <typename T> auto adl_sin(T const& value)
+{
+  using std::sin;
+  return sin(value);
+}
+
+template <typename T> bool adl_isfinite(T const& value)
+{
+  using std::isfinite;
+  return isfinite(value);
+}
+
+template <typename T> auto adl_ceil(T const& value)
+{
+  using std::ceil;
+  return ceil(value);
+}
+
+template <typename T> auto adl_ldexp(T const& value, int exponent)
+{
+  using std::ldexp;
+  return ldexp(value, exponent);
+}
+
+template <typename Scalar>
+DenseMatrix<Scalar>
+linear_combination(std::size_t rows, std::size_t cols,
+                   std::initializer_list<std::pair<DenseMatrix<Scalar> const*, Scalar>> const& terms)
+{
+  DenseMatrix<Scalar> result(rows, cols);
+  for (auto const& term : terms)
+  {
+    DenseMatrix<Scalar> const& mat = *term.first;
+    Scalar const coefficient = term.second;
+    for (std::size_t i = 0; i < rows; ++i)
+    {
+      for (std::size_t j = 0; j < cols; ++j)
+      {
+        result(i, j) += coefficient * mat(i, j);
+      }
+    }
+  }
+  return result;
+}
+
+template <typename Scalar> DenseMatrix<Scalar> solve_pade(DenseMatrix<Scalar> const& U, DenseMatrix<Scalar> const& V)
+{
+  DenseMatrix<Scalar> numerator = add(V, U);
+  DenseMatrix<Scalar> denominator = subtract(V, U);
+  return solve_linear_system(std::move(denominator), std::move(numerator));
+}
+
+template <typename Scalar> DenseMatrix<Scalar> pade3(DenseMatrix<Scalar> const& A)
+{
+  std::array<Scalar, 4> const b{exact_integer<Scalar>(120), exact_integer<Scalar>(60), exact_integer<Scalar>(12),
+                                exact_integer<Scalar>(1)};
+  std::size_t const n = A.rows();
+  DenseMatrix<Scalar> const identity = make_identity<Scalar>(n);
+  DenseMatrix<Scalar> const A2 = multiply(A, A);
+
+  DenseMatrix<Scalar> const tmp = linear_combination<Scalar>(n, n, {{&A2, b[3]}, {&identity, b[1]}});
+  DenseMatrix<Scalar> const U = multiply(A, tmp);
+
+  DenseMatrix<Scalar> const V = linear_combination<Scalar>(n, n, {{&A2, b[2]}, {&identity, b[0]}});
+
+  return solve_pade(U, V);
+}
+
+template <typename Scalar> DenseMatrix<Scalar> pade5(DenseMatrix<Scalar> const& A)
+{
+  std::array<Scalar, 6> const b{exact_integer<Scalar>(30240), exact_integer<Scalar>(15120), exact_integer<Scalar>(3360),
+                                exact_integer<Scalar>(420),   exact_integer<Scalar>(30),    exact_integer<Scalar>(1)};
+  std::size_t const n = A.rows();
+  DenseMatrix<Scalar> const identity = make_identity<Scalar>(n);
+  DenseMatrix<Scalar> const A2 = multiply(A, A);
+  DenseMatrix<Scalar> const A4 = multiply(A2, A2);
+
+  DenseMatrix<Scalar> const tmp = linear_combination<Scalar>(n, n, {{&A4, b[5]}, {&A2, b[3]}, {&identity, b[1]}});
+  DenseMatrix<Scalar> const U = multiply(A, tmp);
+
+  DenseMatrix<Scalar> const V = linear_combination<Scalar>(n, n, {{&A4, b[4]}, {&A2, b[2]}, {&identity, b[0]}});
+
+  return solve_pade(U, V);
+}
+
+template <typename Scalar> DenseMatrix<Scalar> pade7(DenseMatrix<Scalar> const& A)
+{
+  std::array<Scalar, 8> const b{exact_integer<Scalar>(17297280), exact_integer<Scalar>(8648640),
+                                exact_integer<Scalar>(1995840),  exact_integer<Scalar>(277200),
+                                exact_integer<Scalar>(25200),    exact_integer<Scalar>(1512),
+                                exact_integer<Scalar>(56),       exact_integer<Scalar>(1)};
+  std::size_t const n = A.rows();
+  DenseMatrix<Scalar> const identity = make_identity<Scalar>(n);
+  DenseMatrix<Scalar> const A2 = multiply(A, A);
+  DenseMatrix<Scalar> const A4 = multiply(A2, A2);
+  DenseMatrix<Scalar> const A6 = multiply(A4, A2);
+
+  DenseMatrix<Scalar> const tmp =
+      linear_combination<Scalar>(n, n, {{&A6, b[7]}, {&A4, b[5]}, {&A2, b[3]}, {&identity, b[1]}});
+  DenseMatrix<Scalar> const U = multiply(A, tmp);
+
+  DenseMatrix<Scalar> const V =
+      linear_combination<Scalar>(n, n, {{&A6, b[6]}, {&A4, b[4]}, {&A2, b[2]}, {&identity, b[0]}});
+
+  return solve_pade(U, V);
+}
+
+template <typename Scalar> DenseMatrix<Scalar> pade9(DenseMatrix<Scalar> const& A)
+{
+  std::array<Scalar, 10> const b{exact_integer<Scalar>(17643225600LL),
+                                 exact_integer<Scalar>(8821612800LL),
+                                 exact_integer<Scalar>(2075673600),
+                                 exact_integer<Scalar>(302702400),
+                                 exact_integer<Scalar>(30270240),
+                                 exact_integer<Scalar>(2162160),
+                                 exact_integer<Scalar>(110880),
+                                 exact_integer<Scalar>(3960),
+                                 exact_integer<Scalar>(90),
+                                 exact_integer<Scalar>(1)};
+  std::size_t const n = A.rows();
+  DenseMatrix<Scalar> const identity = make_identity<Scalar>(n);
+  DenseMatrix<Scalar> const A2 = multiply(A, A);
+  DenseMatrix<Scalar> const A4 = multiply(A2, A2);
+  DenseMatrix<Scalar> const A6 = multiply(A4, A2);
+  DenseMatrix<Scalar> const A8 = multiply(A6, A2);
+
+  DenseMatrix<Scalar> const tmp =
+      linear_combination<Scalar>(n, n, {{&A8, b[9]}, {&A6, b[7]}, {&A4, b[5]}, {&A2, b[3]}, {&identity, b[1]}});
+  DenseMatrix<Scalar> const U = multiply(A, tmp);
+
+  DenseMatrix<Scalar> const V =
+      linear_combination<Scalar>(n, n, {{&A8, b[8]}, {&A6, b[6]}, {&A4, b[4]}, {&A2, b[2]}, {&identity, b[0]}});
+
+  return solve_pade(U, V);
+}
+
+template <typename Scalar>
+DenseMatrix<Scalar> pade13(DenseMatrix<Scalar> const& A, DenseMatrix<Scalar> const& A2, DenseMatrix<Scalar> const& A4,
+                           DenseMatrix<Scalar> const& A6)
+{
+  std::array<Scalar, 14> const b{exact_integer<Scalar>(64764752532480000LL),
+                                 exact_integer<Scalar>(32382376266240000LL),
+                                 exact_integer<Scalar>(7771770303897600LL),
+                                 exact_integer<Scalar>(1187353796428800LL),
+                                 exact_integer<Scalar>(129060195264000LL),
+                                 exact_integer<Scalar>(10559470521600LL),
+                                 exact_integer<Scalar>(670442572800LL),
+                                 exact_integer<Scalar>(33522128640LL),
+                                 exact_integer<Scalar>(1323241920),
+                                 exact_integer<Scalar>(40840800),
+                                 exact_integer<Scalar>(960960),
+                                 exact_integer<Scalar>(16380),
+                                 exact_integer<Scalar>(182),
+                                 exact_integer<Scalar>(1)};
+
+  std::size_t const n = A.rows();
+  DenseMatrix<Scalar> const identity = make_identity<Scalar>(n);
+
+  DenseMatrix<Scalar> const first = linear_combination<Scalar>(n, n, {{&A6, b[13]}, {&A4, b[11]}, {&A2, b[9]}});
+  DenseMatrix<Scalar> tmp = multiply(A6, first);
+  DenseMatrix<Scalar> const second =
+      linear_combination<Scalar>(n, n, {{&A6, b[7]}, {&A4, b[5]}, {&A2, b[3]}, {&identity, b[1]}});
+  tmp = add(tmp, second);
+  DenseMatrix<Scalar> const U = multiply(A, tmp);
+
+  DenseMatrix<Scalar> const third = linear_combination<Scalar>(n, n, {{&A6, b[12]}, {&A4, b[10]}, {&A2, b[8]}});
+  DenseMatrix<Scalar> V = multiply(A6, third);
+  DenseMatrix<Scalar> const fourth =
+      linear_combination<Scalar>(n, n, {{&A6, b[6]}, {&A4, b[4]}, {&A2, b[2]}, {&identity, b[0]}});
+  V = add(V, fourth);
+
+  return solve_pade(U, V);
+}
+
+template <typename Scalar> int compute_scaling_exponent(DenseMatrix<Scalar> const& A4, DenseMatrix<Scalar> const& A6)
+{
+  using AccumReal = uni20::accumulation_real_t<Scalar>;
+
+  AccumReal const norm4 = matrix_one_norm(A4);
+  AccumReal const norm6 = matrix_one_norm(A6);
+  if (!adl_isfinite(norm4) || !adl_isfinite(norm6))
+  {
+    throw std::overflow_error("matrix powers overflowed while computing matrix_exponential scaling");
+  }
+
+  AccumReal const d4 = adl_pow(norm4, AccumReal{0.25});
+  AccumReal const d6 = adl_pow(norm6, AccumReal{1} / AccumReal{6});
+  AccumReal const eta = std::max(d4, d6);
+  if (eta == AccumReal{})
+  {
+    return 0;
+  }
+
+  AccumReal const ratio = eta / static_cast<AccumReal>(kThetaBounds.back());
+  if (ratio <= AccumReal{1})
+  {
+    return 0;
+  }
+
+  AccumReal const exponent = adl_log2(ratio);
+  if (exponent <= AccumReal{})
+  {
+    return 0;
+  }
+  return static_cast<int>(adl_ceil(exponent));
+}
+
+template <typename Scalar> uni20::accumulation_real_t<Scalar> entry_abs_log2_upper_bound(Scalar const& value)
+{
+  using AccumReal = uni20::accumulation_real_t<Scalar>;
+
+  if constexpr (uni20::Complex<Scalar>)
+  {
+    AccumReal const real = adl_abs(static_cast<AccumReal>(value.real()));
+    AccumReal const imag = adl_abs(static_cast<AccumReal>(value.imag()));
+    if (!adl_isfinite(real) || !adl_isfinite(imag))
+    {
+      throw std::overflow_error("matrix_exponential requires finite matrix entries");
+    }
+
+    AccumReal const component = std::max(real, imag);
+    if (component == AccumReal{})
+    {
+      return -uni20::numeric_limits<AccumReal>::infinity();
+    }
+
+    AccumReal const real_scaled = real / component;
+    AccumReal const imag_scaled = imag / component;
+    AccumReal const factor = adl_sqrt(real_scaled * real_scaled + imag_scaled * imag_scaled);
+    return adl_log2(component) + adl_log2(factor);
+  }
+  else
+  {
+    AccumReal const magnitude = adl_abs(static_cast<AccumReal>(value));
+    if (!adl_isfinite(magnitude))
+    {
+      throw std::overflow_error("matrix_exponential requires finite matrix entries");
+    }
+    if (magnitude == AccumReal{})
+    {
+      return -uni20::numeric_limits<AccumReal>::infinity();
+    }
+    return adl_log2(magnitude);
+  }
+}
+
+template <typename Scalar>
+uni20::accumulation_real_t<Scalar> matrix_max_abs_log2_upper_bound(DenseMatrix<Scalar> const& mat)
+{
+  using AccumReal = uni20::accumulation_real_t<Scalar>;
+
+  AccumReal result = -uni20::numeric_limits<AccumReal>::infinity();
+  for (std::size_t i = 0; i < mat.size(); ++i)
+  {
+    result = std::max(result, entry_abs_log2_upper_bound(mat.data()[i]));
+  }
+  return result;
+}
+
+template <typename Scalar> int compute_prescaling_exponent(DenseMatrix<Scalar> const& A)
+{
+  using Real = uni20::make_real_t<Scalar>;
+  using AccumReal = uni20::accumulation_real_t<Scalar>;
+
+  AccumReal const max_entry_log2 = matrix_max_abs_log2_upper_bound(A);
+  if (max_entry_log2 == -uni20::numeric_limits<AccumReal>::infinity())
+  {
+    return 0;
+  }
+
+  AccumReal const dimension = std::max(AccumReal{1}, static_cast<AccumReal>(A.rows()));
+  AccumReal const safe_power_log2 =
+      AccumReal{-1} + (adl_log2(static_cast<AccumReal>(uni20::numeric_limits<Real>::max())) / AccumReal{6}) -
+      adl_log2(dimension);
+  AccumReal const exponent = max_entry_log2 - safe_power_log2;
+  if (exponent <= AccumReal{})
+  {
+    return 0;
+  }
+  return static_cast<int>(adl_ceil(exponent));
+}
+
+template <typename Scalar> bool has_real_entries(DenseMatrix<Scalar> const& A)
+{
+  if constexpr (!uni20::Complex<Scalar>)
+  {
+    return true;
+  }
+  else
+  {
+    using Real = uni20::make_real_t<Scalar>;
+    for (std::size_t i = 0; i < A.size(); ++i)
+    {
+      if (A.data()[i].imag() != Real{})
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+template <typename OutputScalar, typename InputScalar, typename Coefficient>
+DenseMatrix<OutputScalar> scale_to_output(DenseMatrix<InputScalar> const& matrix, Coefficient const& coefficient)
+{
+  DenseMatrix<OutputScalar> result(matrix.rows(), matrix.cols());
+  for (std::size_t i = 0; i < matrix.size(); ++i)
+  {
+    result.data()[i] = static_cast<OutputScalar>(matrix.data()[i]) * static_cast<OutputScalar>(coefficient);
+  }
+  return result;
+}
+
+template <typename Scalar> uni20::make_real_t<Scalar> real_value(Scalar const& value)
+{
+  if constexpr (uni20::Complex<Scalar>)
+  {
+    return value.real();
+  }
+  else
+  {
+    return value;
+  }
+}
+
+template <typename Scalar> void validate_finite_entries(DenseMatrix<Scalar> const& A)
+{
+  using AccumReal = uni20::accumulation_real_t<Scalar>;
+
+  for (std::size_t i = 0; i < A.size(); ++i)
+  {
+    if constexpr (uni20::Complex<Scalar>)
+    {
+      if (!adl_isfinite(static_cast<AccumReal>(A.data()[i].real())) ||
+          !adl_isfinite(static_cast<AccumReal>(A.data()[i].imag())))
+      {
+        throw std::overflow_error("matrix_exponential requires finite matrix entries");
+      }
+    }
+    else
+    {
+      if (!adl_isfinite(static_cast<AccumReal>(A.data()[i])))
+      {
+        throw std::overflow_error("matrix_exponential requires finite matrix entries");
+      }
+    }
+  }
+}
+
+template <typename Scalar>
+bool try_real_skew_symmetric_3x3_matrix_exponential(DenseMatrix<Scalar> const& A, DenseMatrix<Scalar>& result)
+{
+  using Real = uni20::make_real_t<Scalar>;
+  using AccumReal = uni20::accumulation_real_t<Scalar>;
+
+  if (A.rows() != 3 || A.cols() != 3 || !has_real_entries(A))
+  {
+    return false;
+  }
+
+  if (A(0, 0) != Scalar{} || A(1, 1) != Scalar{} || A(2, 2) != Scalar{} || A(0, 1) != -A(1, 0) || A(0, 2) != -A(2, 0) ||
+      A(1, 2) != -A(2, 1))
+  {
+    return false;
+  }
+
+  Real const x = -real_value(A(1, 2));
+  Real const y = real_value(A(0, 2));
+  Real const z = -real_value(A(0, 1));
+  AccumReal const max_component = std::max(
+      {adl_abs(static_cast<AccumReal>(x)), adl_abs(static_cast<AccumReal>(y)), adl_abs(static_cast<AccumReal>(z))});
+  if (max_component == AccumReal{})
+  {
+    result = make_identity<Scalar>(3);
+    return true;
+  }
+  if (!adl_isfinite(max_component))
+  {
+    throw std::overflow_error("matrix_exponential requires finite matrix entries");
+  }
+
+  AccumReal const x_scaled = static_cast<AccumReal>(x) / max_component;
+  AccumReal const y_scaled = static_cast<AccumReal>(y) / max_component;
+  AccumReal const z_scaled = static_cast<AccumReal>(z) / max_component;
+  AccumReal const norm_scaled = adl_sqrt(x_scaled * x_scaled + y_scaled * y_scaled + z_scaled * z_scaled);
+  AccumReal const theta = max_component * norm_scaled;
+  if (!adl_isfinite(theta))
+  {
+    return false;
+  }
+
+  Real const ux = static_cast<Real>(x_scaled / norm_scaled);
+  Real const uy = static_cast<Real>(y_scaled / norm_scaled);
+  Real const uz = static_cast<Real>(z_scaled / norm_scaled);
+  DenseMatrix<Scalar> K(3, 3);
+  K(0, 1) = Scalar(-uz);
+  K(0, 2) = Scalar(uy);
+  K(1, 0) = Scalar(uz);
+  K(1, 2) = Scalar(-ux);
+  K(2, 0) = Scalar(-uy);
+  K(2, 1) = Scalar(ux);
+
+  AccumReal const half_theta = theta / AccumReal{2};
+  AccumReal const sin_half_theta = adl_sin(half_theta);
+  Real const sine = static_cast<Real>(adl_sin(theta));
+  Real const one_minus_cosine = static_cast<Real>(AccumReal{2} * sin_half_theta * sin_half_theta);
+  DenseMatrix<Scalar> const K2 = multiply(K, K);
+  result = add(add(make_identity<Scalar>(3), scale(K, sine)), scale(K2, one_minus_cosine));
+  return true;
+}
+
+template <uni20::RealOrComplex Scalar> DenseMatrix<Scalar> matrix_exponential_scaled(DenseMatrix<Scalar> A)
+{
+  using Real = uni20::make_real_t<Scalar>;
+
+  if (A.rows() != A.cols())
+  {
+    throw std::invalid_argument("matrix_exponential requires a square matrix");
+  }
+
+  if (A.rows() == 0)
+  {
+    return DenseMatrix<Scalar>();
+  }
+
+  std::size_t const n = A.rows();
+  detail::validate_finite_entries(A);
+
+  uni20::accumulation_real_t<Scalar> const normA = matrix_one_norm(A);
+  if (normA == uni20::accumulation_real_t<Scalar>{})
+  {
+    return make_identity<Scalar>(n);
+  }
+  DenseMatrix<Scalar> skew_symmetric_3x3_result;
+  if (detail::try_real_skew_symmetric_3x3_matrix_exponential(A, skew_symmetric_3x3_result))
+  {
+    return skew_symmetric_3x3_result;
+  }
+  if (!adl_isfinite(normA))
+  {
+    throw std::overflow_error("matrix_exponential requires a finite matrix norm");
+  }
+
+  if (normA <= detail::kThetaBounds[0])
+  {
+    return detail::pade3(A);
+  }
+  if (normA <= detail::kThetaBounds[1])
+  {
+    return detail::pade5(A);
+  }
+  if (normA <= detail::kThetaBounds[2])
+  {
+    return detail::pade7(A);
+  }
+  if (normA <= detail::kThetaBounds[3])
+  {
+    return detail::pade9(A);
+  }
+
+  int const prescaling = detail::compute_prescaling_exponent(A);
+  if (prescaling != 0)
+  {
+    Real const prescale = adl_ldexp(Real{1}, -prescaling);
+    A = scale(std::move(A), prescale);
+  }
+
+  DenseMatrix<Scalar> A2 = multiply(A, A);
+  DenseMatrix<Scalar> A4 = multiply(A2, A2);
+  DenseMatrix<Scalar> A6 = multiply(A4, A2);
+
+  int const additional_scaling = detail::compute_scaling_exponent(A4, A6);
+  int const s = prescaling + additional_scaling;
+
+  DenseMatrix<Scalar> A2_scaled;
+  DenseMatrix<Scalar> A4_scaled;
+  DenseMatrix<Scalar> A6_scaled;
+  if (additional_scaling == 0)
+  {
+    A2_scaled = std::move(A2);
+    A4_scaled = std::move(A4);
+    A6_scaled = std::move(A6);
+  }
+  else
+  {
+    Real const scale_real = adl_ldexp(Real{1}, -additional_scaling);
+    Real const scale_sq = scale_real * scale_real;
+    Real const scale_pow4 = scale_sq * scale_sq;
+    Real const scale_pow6 = scale_pow4 * scale_sq;
+    A = scale(std::move(A), scale_real);
+    A2_scaled = scale(std::move(A2), scale_sq);
+    A4_scaled = scale(std::move(A4), scale_pow4);
+    A6_scaled = scale(std::move(A6), scale_pow6);
+  }
+
+  DenseMatrix<Scalar> result = detail::pade13(A, A2_scaled, A4_scaled, A6_scaled);
+  for (int k = 0; k < s; ++k)
+  {
+    result = multiply(result, result);
+  }
+
+  return result;
+}
+
+} // namespace detail
+
+template <uni20::RealOrComplex Scalar>
+DenseMatrix<Scalar> matrix_exponential(DenseMatrix<Scalar> const& matrix, uni20::make_real_t<Scalar> t)
+{
+  return detail::matrix_exponential_scaled(detail::scale_to_output<Scalar>(matrix, t));
+}
+
+template <uni20::RealOrComplex Scalar>
+DenseMatrix<uni20::complex<uni20::make_real_t<Scalar>>> matrix_exponential(DenseMatrix<Scalar> const& matrix,
+                                                                           uni20::complex<uni20::make_real_t<Scalar>> t)
+{
+  using OutputScalar = uni20::complex<uni20::make_real_t<Scalar>>;
+  return detail::matrix_exponential_scaled(detail::scale_to_output<OutputScalar>(matrix, t));
+}
+
+template DenseMatrix<float> matrix_exponential(DenseMatrix<float> const&, float);
+template DenseMatrix<double> matrix_exponential(DenseMatrix<double> const&, double);
+template DenseMatrix<long double> matrix_exponential(DenseMatrix<long double> const&, long double);
+template DenseMatrix<uni20::complex<float>> matrix_exponential(DenseMatrix<uni20::complex<float>> const&, float);
+template DenseMatrix<uni20::complex<double>> matrix_exponential(DenseMatrix<uni20::complex<double>> const&, double);
+template DenseMatrix<uni20::complex<long double>> matrix_exponential(DenseMatrix<uni20::complex<long double>> const&,
+                                                                     long double);
+
+template DenseMatrix<uni20::complex<float>> matrix_exponential(DenseMatrix<float> const&, uni20::complex<float>);
+template DenseMatrix<uni20::complex<double>> matrix_exponential(DenseMatrix<double> const&, uni20::complex<double>);
+template DenseMatrix<uni20::complex<long double>> matrix_exponential(DenseMatrix<long double> const&,
+                                                                     uni20::complex<long double>);
+template DenseMatrix<uni20::complex<float>> matrix_exponential(DenseMatrix<uni20::complex<float>> const&,
+                                                               uni20::complex<float>);
+template DenseMatrix<uni20::complex<double>> matrix_exponential(DenseMatrix<uni20::complex<double>> const&,
+                                                                uni20::complex<double>);
+template DenseMatrix<uni20::complex<long double>> matrix_exponential(DenseMatrix<uni20::complex<long double>> const&,
+                                                                     uni20::complex<long double>);
+
+#if defined(UNI20_ENABLE_MPLAPACK) && defined(MPLAPACK_BINARY128_MODE) &&                                              \
+    (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
+template DenseMatrix<mplapack_binary128_t> matrix_exponential(DenseMatrix<mplapack_binary128_t> const&,
+                                                              mplapack_binary128_t);
+template DenseMatrix<uni20::complex<mplapack_binary128_t>>
+matrix_exponential(DenseMatrix<uni20::complex<mplapack_binary128_t>> const&, mplapack_binary128_t);
+template DenseMatrix<uni20::complex<mplapack_binary128_t>> matrix_exponential(DenseMatrix<mplapack_binary128_t> const&,
+                                                                              uni20::complex<mplapack_binary128_t>);
+template DenseMatrix<uni20::complex<mplapack_binary128_t>>
+matrix_exponential(DenseMatrix<uni20::complex<mplapack_binary128_t>> const&, uni20::complex<mplapack_binary128_t>);
+#endif
+
+} // namespace uni20::linalg::backends::cpu

--- a/src/uni20/linalg/backends/cpu/matrix_exponential.hpp
+++ b/src/uni20/linalg/backends/cpu/matrix_exponential.hpp
@@ -1,0 +1,41 @@
+/**
+ * \file matrix_exponential.hpp
+ * \brief CPU dense matrix exponential interface.
+ */
+
+#pragma once
+
+#if defined(UNI20_ENABLE_MPLAPACK)
+#include <mplapack_config.h>
+#endif
+#include <complex>
+
+#include <uni20/core/scalar_concepts.hpp>
+#include <uni20/linalg/backends/cpu/dense_matrix.hpp>
+
+namespace uni20::linalg::backends::cpu
+{
+
+/// \brief Compute the matrix exponential using the adaptive scaling-and-squaring algorithm.
+/// \details Follows the Pad\'e-based scaling and squaring strategy of Higham (2005) and
+///          Al-Mohy & Higham (2011). The routine automatically selects between Pad\'e
+///          degrees {3, 5, 7, 9, 13} based on matrix norms.
+/// \tparam Scalar Dense matrix element type; may be real or complex in single, double, or extended precision.
+/// \param matrix Dense matrix whose exponential will be evaluated.
+/// \param t Scalar multiplier applied to \p matrix before exponentiation.
+/// \return The matrix exponential of \f$\exp(t \cdot \text{matrix})\f$.
+template <uni20::RealOrComplex Scalar>
+DenseMatrix<Scalar> matrix_exponential(DenseMatrix<Scalar> const& matrix, uni20::make_real_t<Scalar> t);
+
+/// \brief Compute a complex-coefficient matrix exponential, promoting real matrices to complex output.
+/// \details This overload evaluates \f$\exp(t A)\f$ for complex \p t. If \p matrix is real, the result
+///          is promoted to a complex dense matrix. If \p matrix is already complex, the result remains complex.
+/// \tparam Scalar Real or complex matrix element type.
+/// \param matrix Dense matrix whose exponential will be evaluated.
+/// \param t Complex multiplier applied to \p matrix before exponentiation.
+/// \return The complex matrix exponential of \f$\exp(t \cdot \text{matrix})\f$.
+template <uni20::RealOrComplex Scalar>
+DenseMatrix<uni20::complex<uni20::make_real_t<Scalar>>>
+matrix_exponential(DenseMatrix<Scalar> const& matrix, uni20::complex<uni20::make_real_t<Scalar>> t);
+
+} // namespace uni20::linalg::backends::cpu

--- a/src/uni20/linalg/backends/cpu/matrix_ops_cpu.hpp
+++ b/src/uni20/linalg/backends/cpu/matrix_ops_cpu.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <uni20/core/scalar_traits.hpp>
 #include <uni20/core/types.hpp>
 #include <uni20/tags/cpu.hpp>
 #include <uni20/tensor/tensor_view.hpp>
@@ -228,16 +229,18 @@ void scale(TensorView<TMat const, MatTraits> mat, Scalar const& scalar, TensorVi
 /// \tparam Traits Trait bundle describing the matrix view.
 /// \param mat Matrix view whose norm is computed.
 /// \return The induced matrix 1-norm.
-template <typename T, typename Traits> double matrix_one_norm(TensorView<T const, Traits> mat)
+template <typename T, typename Traits> uni20::accumulation_real_t<T> matrix_one_norm(TensorView<T const, Traits> mat)
 {
   util::require_rank_two(mat);
 
+  using Real = uni20::accumulation_real_t<T>;
+
   auto mat_span = util::const_span(mat);
-  double result = 0.0;
+  Real result = Real{};
 
   for (index_type j = 0; j < mat.cols(); ++j)
   {
-    double column_sum = 0.0;
+    Real column_sum = Real{};
     for (index_type i = 0; i < mat.rows(); ++i)
     {
       column_sum += std::abs(mat_span[i, j]);
@@ -303,15 +306,22 @@ void solve_linear_system(TensorView<TA, ATraits> A, TensorView<TB, BTraits> B)
   auto A_span = util::mutable_span(A);
   auto B_span = util::mutable_span(B);
 
-  using value_type = std::remove_cv_t<typename TensorView<TB, BTraits>::value_type>;
+  using coefficient_value_type = std::remove_cv_t<typename TensorView<TA, ATraits>::value_type>;
+  using rhs_value_type = std::remove_cv_t<typename TensorView<TB, BTraits>::value_type>;
+  using pivot_real = uni20::accumulation_real_t<coefficient_value_type>;
+
+  auto magnitude = [](auto const& value) -> pivot_real {
+    using std::abs;
+    return static_cast<pivot_real>(abs(value));
+  };
 
   for (index_type k = 0; k < n; ++k)
   {
     index_type pivot_row = k;
-    double pivot_value = std::abs(A_span[k, k]);
+    pivot_real pivot_value = magnitude(A_span[k, k]);
     for (index_type i = k + 1; i < n; ++i)
     {
-      double const candidate = std::abs(A_span[i, k]);
+      pivot_real const candidate = magnitude(A_span[i, k]);
       if (candidate > pivot_value)
       {
         pivot_value = candidate;
@@ -319,7 +329,7 @@ void solve_linear_system(TensorView<TA, ATraits> A, TensorView<TB, BTraits> B)
       }
     }
 
-    if (pivot_value == 0.0)
+    if (pivot_value == pivot_real{})
     {
       throw std::runtime_error("singular matrix in solve_linear_system");
     }
@@ -332,15 +342,15 @@ void solve_linear_system(TensorView<TA, ATraits> A, TensorView<TB, BTraits> B)
       B_span = util::mutable_span(B);
     }
 
-    value_type const pivot = A_span[k, k];
+    coefficient_value_type const pivot = A_span[k, k];
     for (index_type i = k + 1; i < n; ++i)
     {
-      value_type const factor = A_span[i, k] / pivot;
-      if (factor == value_type{})
+      coefficient_value_type const factor = A_span[i, k] / pivot;
+      if (factor == coefficient_value_type{})
       {
         continue;
       }
-      A_span[i, k] = value_type{};
+      A_span[i, k] = coefficient_value_type{};
       for (index_type j = k + 1; j < n; ++j)
       {
         A_span[i, j] -= factor * A_span[k, j];
@@ -354,10 +364,10 @@ void solve_linear_system(TensorView<TA, ATraits> A, TensorView<TB, BTraits> B)
 
   for (index_type i = n; i-- > 0;)
   {
-    value_type const pivot = A_span[i, i];
+    coefficient_value_type const pivot = A_span[i, i];
     for (index_type j = 0; j < nrhs; ++j)
     {
-      value_type value = B_span[i, j];
+      rhs_value_type value = B_span[i, j];
       for (index_type k = i + 1; k < n; ++k)
       {
         value -= A_span[i, k] * B_span[k, j];
@@ -409,7 +419,8 @@ void scale_into(TensorView<TMat const, MatTraits> mat, Scalar const& scalar, Ten
   backends::cpu::detail::scale(mat, scalar, out);
 }
 
-template <typename T, typename Traits> double matrix_one_norm(TensorView<T const, Traits> mat, cpu_tag)
+template <typename T, typename Traits>
+uni20::accumulation_real_t<T> matrix_one_norm(TensorView<T const, Traits> mat, cpu_tag)
 {
   return backends::cpu::detail::matrix_one_norm(mat);
 }

--- a/src/uni20/linalg/ops/matrix_ops.hpp
+++ b/src/uni20/linalg/ops/matrix_ops.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <uni20/core/scalar_traits.hpp>
 #include <uni20/core/types.hpp>
 #include <uni20/linalg/backend_manifest.hpp>
 #include <uni20/storage/vectorstorage.hpp>
@@ -28,8 +29,8 @@ template <typename FirstView, typename... RestViews>
 constexpr auto select_tag(FirstView const&, RestViews const&...) -> select_tag_t<FirstView, RestViews...>
 {
   using tag_type = select_tag_t<FirstView, RestViews...>;
-  static_assert((std::is_convertible_v<default_tag_t<FirstView>, tag_type>)&&(
-                    ... && std::is_convertible_v<default_tag_t<RestViews>, tag_type>),
+  static_assert((std::is_convertible_v<default_tag_t<FirstView>, tag_type>) &&
+                    (... && std::is_convertible_v<default_tag_t<RestViews>, tag_type>),
                 "TensorView arguments must share a compatible backend tag");
   return tag_type{};
 }
@@ -268,7 +269,7 @@ auto scale(TensorView<T const, MatTraits> mat, Scalar const& scalar)
 /// \tparam Traits Trait bundle describing the matrix view.
 /// \param mat Matrix view whose norm is computed.
 /// \return The induced 1-norm of mat.
-template <typename T, typename Traits> double matrix_one_norm(TensorView<T const, Traits> mat)
+template <typename T, typename Traits> uni20::accumulation_real_t<T> matrix_one_norm(TensorView<T const, Traits> mat)
 {
   auto const tag = detail::select_tag(mat);
   return ::uni20::linalg::matrix_one_norm(mat, tag);
@@ -366,14 +367,15 @@ template <typename T, typename MatTraits> auto matrix_power(TensorView<T const, 
 /// \param power Non-negative integer exponent.
 /// \return Induced matrix 1-norm of mat^power.
 template <typename T, typename MatTraits, typename BackendTag>
-double matrix_one_norm_power(TensorView<T const, MatTraits> mat, unsigned int power, BackendTag tag)
+uni20::accumulation_real_t<T> matrix_one_norm_power(TensorView<T const, MatTraits> mat, unsigned int power,
+                                                    BackendTag tag)
 {
   auto powered = matrix_power(mat, power, tag);
   return ::uni20::linalg::matrix_one_norm(powered.view(), tag);
 }
 
 template <typename T, typename MatTraits>
-double matrix_one_norm_power(TensorView<T const, MatTraits> mat, unsigned int power)
+uni20::accumulation_real_t<T> matrix_one_norm_power(TensorView<T const, MatTraits> mat, unsigned int power)
 {
   auto const tag = detail::select_tag(mat);
   return matrix_one_norm_power(mat, power, tag);

--- a/tests/backend/blas/CMakeLists.txt
+++ b/tests/backend/blas/CMakeLists.txt
@@ -1,6 +1,6 @@
 # tests/common/CMakeLists.txt
 
 add_test_module(reference_blas
-  SOURCES test_reference_blas_gem.cpp test_vendor_backends.cpp
+  SOURCES test_reference_blas_gem.cpp test_reference_lapack.cpp test_vendor_backends.cpp
   LIBS uni20_common uni20_backend_blas
 )

--- a/tests/backend/blas/test_reference_lapack.cpp
+++ b/tests/backend/blas/test_reference_lapack.cpp
@@ -1,0 +1,25 @@
+#include <uni20/backend/lapack/lapack.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <vector>
+
+TEST(LAPACKWrapper, GesvSolvesDoubleSystem)
+{
+  uni20::blas_int const n = 2;
+  uni20::blas_int const nrhs = 1;
+  std::vector<double> a{
+      3.0,
+      1.0,
+      1.0,
+      2.0,
+  };
+  std::vector<double> b{9.0, 8.0};
+  std::vector<uni20::blas_int> ipiv(static_cast<std::size_t>(n));
+
+  uni20::lapack::gesv(n, nrhs, a.data(), n, ipiv.data(), b.data(), n);
+
+  EXPECT_NEAR(b[0], 2.0, 1e-12);
+  EXPECT_NEAR(b[1], 3.0, 1e-12);
+}

--- a/tests/linalg/CMakeLists.txt
+++ b/tests/linalg/CMakeLists.txt
@@ -1,4 +1,18 @@
 add_test_module(linalg
-  SOURCES test_cpu_ops.cpp
+  SOURCES
+    test_cpu_ops.cpp
+    cpu/test_matrix_exponential.cpp
   LIBS uni20_linalg
 )
+
+if(UNI20_ENABLE_MPLAPACK)
+  add_executable(uni20_linalg_mplapack_binary128_tests test_mplapack_binary128_cpu_ops.cpp)
+  target_link_libraries(uni20_linalg_mplapack_binary128_tests
+    PRIVATE
+      uni20_linalg
+      mplapack::mplapack_binary128
+      GTest::gtest_main
+  )
+  target_compile_definitions(uni20_linalg_mplapack_binary128_tests PRIVATE UNIT_TEST)
+  gtest_discover_tests(uni20_linalg_mplapack_binary128_tests)
+endif()

--- a/tests/linalg/cpu/test_matrix_exponential.cpp
+++ b/tests/linalg/cpu/test_matrix_exponential.cpp
@@ -1,0 +1,365 @@
+#include <gtest/gtest.h>
+
+#include <uni20/core/scalar_concepts.hpp>
+#include <uni20/linalg/backends/cpu/matrix_exponential.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <numbers>
+#include <type_traits>
+
+namespace
+{
+
+namespace cpu_linalg = uni20::linalg::backends::cpu;
+
+template <typename Scalar> using DenseMatrix = cpu_linalg::DenseMatrix<Scalar>;
+
+template <typename Scalar> double DefaultTolerance()
+{
+  if constexpr (std::is_same_v<uni20::make_real_t<Scalar>, float>)
+  {
+    return 1.0e-5;
+  }
+  else
+  {
+    return 1.0e-12;
+  }
+}
+
+template <typename Scalar> double RelaxedTolerance()
+{
+  if constexpr (std::is_same_v<uni20::make_real_t<Scalar>, float>)
+  {
+    return 5.0e-4;
+  }
+  else
+  {
+    return 1.0e-10;
+  }
+}
+
+template <typename Scalar>
+void ExpectMatrixNear(DenseMatrix<Scalar> const& actual, DenseMatrix<Scalar> const& expected, double tol)
+{
+  ASSERT_EQ(actual.rows(), expected.rows());
+  ASSERT_EQ(actual.cols(), expected.cols());
+
+  for (std::size_t i = 0; i < actual.rows(); ++i)
+  {
+    for (std::size_t j = 0; j < actual.cols(); ++j)
+    {
+      double const difference = static_cast<double>(std::abs(actual(i, j) - expected(i, j)));
+      double const magnitude = std::max(1.0, static_cast<double>(std::abs(expected(i, j))));
+      EXPECT_LE(difference, tol * magnitude)
+          << "entry (" << i << ", " << j << ") differs: actual=" << actual(i, j) << " expected=" << expected(i, j);
+    }
+  }
+}
+
+template <typename Scalar> void ExpectFiniteBounded(Scalar const& value, double bound)
+{
+  if constexpr (uni20::Complex<Scalar>)
+  {
+    EXPECT_TRUE(std::isfinite(static_cast<double>(value.real()))) << "value=" << value;
+    EXPECT_TRUE(std::isfinite(static_cast<double>(value.imag()))) << "value=" << value;
+  }
+  else
+  {
+    EXPECT_TRUE(std::isfinite(static_cast<double>(value))) << "value=" << value;
+  }
+
+  EXPECT_LT(static_cast<double>(std::abs(value)), bound) << "value=" << value;
+}
+
+template <typename Scalar> DenseMatrix<Scalar> MakeIdentity(std::size_t order)
+{
+  using Real = uni20::make_real_t<Scalar>;
+  DenseMatrix<Scalar> identity(order, order);
+  for (std::size_t i = 0; i < order; ++i)
+  {
+    for (std::size_t j = 0; j < order; ++j)
+    {
+      identity(i, j) = (i == j) ? Scalar(Real{1}) : Scalar();
+    }
+  }
+  return identity;
+}
+
+template <typename Scalar> DenseMatrix<Scalar> MakeZeroMatrix(std::size_t order)
+{
+  return DenseMatrix<Scalar>(order, order);
+}
+
+template <typename Scalar> Scalar MakeScalarValue()
+{
+  using Real = uni20::make_real_t<Scalar>;
+  if constexpr (uni20::Complex<Scalar>)
+  {
+    return Scalar(Real{2.0}, Real{-0.5});
+  }
+  else
+  {
+    return Scalar(Real{2.0});
+  }
+}
+
+template <typename Scalar> Scalar MakeLargeOffDiagonal()
+{
+  using Real = uni20::make_real_t<Scalar>;
+  return Scalar(Real{1000.0});
+}
+
+template <typename Scalar> Scalar MakeLargeDiagonal()
+{
+  using Real = uni20::make_real_t<Scalar>;
+  return Scalar(Real{10.0});
+}
+
+template <typename Scalar> Scalar MakeZero() { return Scalar(); }
+
+template <typename Scalar> Scalar MakeOne()
+{
+  using Real = uni20::make_real_t<Scalar>;
+  return Scalar(Real{1});
+}
+
+template <typename Scalar> Scalar MakeNegativeOne()
+{
+  using Real = uni20::make_real_t<Scalar>;
+  return Scalar(Real{-1});
+}
+
+template <typename Scalar> Scalar MakeLargeNilpotent()
+{
+  using Real = uni20::make_real_t<Scalar>;
+  return Scalar(Real{1.0e3});
+}
+
+template <typename Scalar> uni20::make_real_t<Scalar> MakeHugeSkewTheta()
+{
+  using Real = uni20::make_real_t<Scalar>;
+  if constexpr (std::is_same_v<Real, float>)
+  {
+    return Real{1.0e20F};
+  }
+  else
+  {
+    return Real{1.0e80};
+  }
+}
+
+} // namespace
+
+template <typename Scalar> class MatrixExponentialTypedTest : public ::testing::Test {};
+
+using MatrixExponentialTypes = ::testing::Types<float, double, long double, uni20::complex<float>,
+                                                uni20::complex<double>, uni20::complex<long double>>;
+TYPED_TEST_SUITE(MatrixExponentialTypedTest, MatrixExponentialTypes);
+
+TYPED_TEST(MatrixExponentialTypedTest, ZeroMatrixReturnsIdentity)
+{
+  using Scalar = TypeParam;
+  using Real = uni20::make_real_t<Scalar>;
+  DenseMatrix<Scalar> const matrix = MakeZeroMatrix<Scalar>(3);
+
+  DenseMatrix<Scalar> const result = cpu_linalg::matrix_exponential(matrix, Real{1});
+  DenseMatrix<Scalar> const expected = MakeIdentity<Scalar>(3);
+
+  ExpectMatrixNear(result, expected, DefaultTolerance<Scalar>());
+}
+
+TYPED_TEST(MatrixExponentialTypedTest, RejectsNaNEntryBeforeZeroNormShortcut)
+{
+  using Scalar = TypeParam;
+  using Real = uni20::make_real_t<Scalar>;
+  DenseMatrix<Scalar> matrix(2, 2);
+  matrix(0, 0) = Scalar(uni20::numeric_limits<Real>::quiet_NaN());
+
+  EXPECT_THROW(cpu_linalg::matrix_exponential(matrix, Real{1}), std::overflow_error);
+}
+
+TYPED_TEST(MatrixExponentialTypedTest, ScalarMatrixMatchesScalarExponential)
+{
+  using Scalar = TypeParam;
+  using Real = uni20::make_real_t<Scalar>;
+  DenseMatrix<Scalar> matrix(1, 1);
+  Scalar const entry = MakeScalarValue<Scalar>();
+  matrix(0, 0) = entry;
+
+  DenseMatrix<Scalar> const result = cpu_linalg::matrix_exponential(matrix, Real{1});
+
+  Scalar const expected = std::exp(entry);
+  double const tolerance = DefaultTolerance<Scalar>();
+  double const diff = static_cast<double>(std::abs(result(0, 0) - expected));
+  double const magnitude = std::max(1.0, static_cast<double>(std::abs(expected)));
+  EXPECT_LE(diff, tolerance * magnitude);
+}
+
+TEST(MatrixExponentialTest, RealMatrixWithComplexMultiplierPromotesToComplex)
+{
+  DenseMatrix<double> matrix(1, 1);
+  matrix(0, 0) = 2.0;
+
+  uni20::complex<double> const time{0.0, std::numbers::pi / 2.0};
+  auto const result = cpu_linalg::matrix_exponential(matrix, time);
+
+  static_assert(std::is_same_v<decltype(result), DenseMatrix<uni20::complex<double>> const>);
+  uni20::complex<double> const expected = std::exp(time * matrix(0, 0));
+  EXPECT_LE(std::abs(result(0, 0) - expected), 1.0e-12);
+}
+
+TEST(MatrixExponentialTest, ComplexMatrixWithComplexMultiplierUsesComplexTime)
+{
+  DenseMatrix<uni20::complex<double>> matrix(1, 1);
+  matrix(0, 0) = uni20::complex<double>{1.0, -0.25};
+
+  uni20::complex<double> const time{0.2, -0.3};
+  auto const result = cpu_linalg::matrix_exponential(matrix, time);
+
+  uni20::complex<double> const expected = std::exp(time * matrix(0, 0));
+  EXPECT_LE(std::abs(result(0, 0) - expected), 1.0e-12);
+}
+
+TYPED_TEST(MatrixExponentialTypedTest, SkewSymmetricGeneratesRotation)
+{
+  using Scalar = TypeParam;
+  using Real = uni20::make_real_t<Scalar>;
+  DenseMatrix<Scalar> matrix(2, 2);
+  matrix(0, 0) = MakeZero<Scalar>();
+  matrix(0, 1) = MakeNegativeOne<Scalar>();
+  matrix(1, 0) = MakeOne<Scalar>();
+  matrix(1, 1) = MakeZero<Scalar>();
+
+  Real const angle = std::numbers::pi_v<Real> / Real{2};
+  DenseMatrix<Scalar> const result = cpu_linalg::matrix_exponential(matrix, angle);
+
+  DenseMatrix<Scalar> expected(2, 2);
+  Real const cosine = std::cos(angle);
+  Real const sine = std::sin(angle);
+  expected(0, 0) = Scalar(cosine);
+  expected(0, 1) = Scalar(-sine);
+  expected(1, 0) = Scalar(sine);
+  expected(1, 1) = Scalar(cosine);
+
+  ExpectMatrixNear(result, expected, RelaxedTolerance<Scalar>());
+}
+
+TEST(MatrixExponentialTest, LongDoubleNilpotentUsesExtendedPrecisionScaling)
+{
+  DenseMatrix<long double> matrix(2, 2);
+  long double const large = std::ldexp(1.0L, uni20::numeric_limits<long double>::max_exponent - 2);
+  ASSERT_TRUE(std::isfinite(large));
+  matrix(0, 1) = large;
+
+  DenseMatrix<long double> const result = cpu_linalg::matrix_exponential(matrix, 1.0L);
+
+  long double constexpr tolerance = 1.0e-12L;
+  EXPECT_LE(std::abs(result(0, 0) - 1.0L), tolerance);
+  EXPECT_LE(std::abs(result(1, 0)), tolerance);
+  EXPECT_LE(std::abs(result(1, 1) - 1.0L), tolerance);
+  EXPECT_LE(std::abs((result(0, 1) - large) / large), tolerance);
+}
+
+TYPED_TEST(MatrixExponentialTypedTest, HugeSkewSymmetricGeneratorStaysFinite)
+{
+  using Scalar = TypeParam;
+  using Real = uni20::make_real_t<Scalar>;
+  DenseMatrix<Scalar> matrix(2, 2);
+  Real const theta = MakeHugeSkewTheta<Scalar>();
+  matrix(0, 0) = MakeZero<Scalar>();
+  matrix(0, 1) = Scalar(-theta);
+  matrix(1, 0) = Scalar(theta);
+  matrix(1, 1) = MakeZero<Scalar>();
+
+  DenseMatrix<Scalar> const result = cpu_linalg::matrix_exponential(matrix, Real{1});
+
+  ExpectFiniteBounded(result(0, 0), 2.0);
+  ExpectFiniteBounded(result(0, 1), 2.0);
+  ExpectFiniteBounded(result(1, 0), 2.0);
+  ExpectFiniteBounded(result(1, 1), 2.0);
+}
+
+template <typename Scalar> void RunOverflowedOneNormSkewSymmetricGeneratorStaysFinite()
+{
+  using Real = uni20::make_real_t<Scalar>;
+  Real const theta = Real{1.0e308};
+  DenseMatrix<Scalar> matrix(3, 3);
+  matrix(0, 0) = MakeZero<Scalar>();
+  matrix(0, 1) = Scalar(-theta);
+  matrix(0, 2) = Scalar(theta);
+  matrix(1, 0) = Scalar(theta);
+  matrix(1, 1) = MakeZero<Scalar>();
+  matrix(1, 2) = Scalar(-theta);
+  matrix(2, 0) = Scalar(-theta);
+  matrix(2, 1) = Scalar(theta);
+  matrix(2, 2) = MakeZero<Scalar>();
+
+  DenseMatrix<Scalar> const result = cpu_linalg::matrix_exponential(matrix, Real{1});
+
+  for (std::size_t i = 0; i < result.rows(); ++i)
+  {
+    for (std::size_t j = 0; j < result.cols(); ++j)
+    {
+      ExpectFiniteBounded(result(i, j), 2.0);
+    }
+  }
+}
+
+TEST(MatrixExponentialTest, OverflowedOneNormSkewSymmetricGeneratorStaysFinite)
+{
+  RunOverflowedOneNormSkewSymmetricGeneratorStaysFinite<double>();
+  RunOverflowedOneNormSkewSymmetricGeneratorStaysFinite<uni20::complex<double>>();
+}
+
+TYPED_TEST(MatrixExponentialTypedTest, HighNormJordanBlockMatchesAnalyticSolution)
+{
+  using Scalar = TypeParam;
+  using Real = uni20::make_real_t<Scalar>;
+  DenseMatrix<Scalar> matrix(2, 2);
+  Scalar const diag = MakeLargeDiagonal<Scalar>();
+  Scalar const off = MakeLargeOffDiagonal<Scalar>();
+  matrix(0, 0) = diag;
+  matrix(0, 1) = off;
+  matrix(1, 0) = MakeZero<Scalar>();
+  matrix(1, 1) = diag;
+
+  DenseMatrix<Scalar> const result = cpu_linalg::matrix_exponential(matrix, Real{1});
+
+  Scalar const exp_diag = std::exp(diag);
+  DenseMatrix<Scalar> expected(2, 2);
+  expected(0, 0) = exp_diag;
+  expected(0, 1) = exp_diag * off;
+  expected(1, 0) = MakeZero<Scalar>();
+  expected(1, 1) = exp_diag;
+
+  ExpectMatrixNear(result, expected, RelaxedTolerance<Scalar>());
+}
+
+TYPED_TEST(MatrixExponentialTypedTest, NilpotentChainMatchesSeries)
+{
+  using Scalar = TypeParam;
+  using Real = uni20::make_real_t<Scalar>;
+  DenseMatrix<Scalar> matrix(3, 3);
+  Scalar const large = MakeLargeNilpotent<Scalar>();
+  matrix(0, 0) = MakeZero<Scalar>();
+  matrix(0, 1) = large;
+  matrix(0, 2) = MakeZero<Scalar>();
+  matrix(1, 0) = MakeZero<Scalar>();
+  matrix(1, 1) = MakeZero<Scalar>();
+  matrix(1, 2) = large;
+  matrix(2, 0) = MakeZero<Scalar>();
+  matrix(2, 1) = MakeZero<Scalar>();
+  matrix(2, 2) = MakeZero<Scalar>();
+
+  DenseMatrix<Scalar> const result = cpu_linalg::matrix_exponential(matrix, Real{1});
+
+  DenseMatrix<Scalar> expected = MakeIdentity<Scalar>(3);
+  DenseMatrix<Scalar> const matrix_squared = cpu_linalg::matrix_power(matrix, 2);
+  DenseMatrix<Scalar> const scaled_matrix = cpu_linalg::add(matrix, cpu_linalg::scale(matrix_squared, Real{0.5}));
+  expected = cpu_linalg::add(expected, scaled_matrix);
+
+  ExpectMatrixNear(result, expected, RelaxedTolerance<Scalar>());
+}


### PR DESCRIPTION
Authored by: Codex (OpenAI), working from Ian McCulloch's Uni20 integration branch.

For review: this PR adds the first dense linalg infrastructure slice needed before the native Krylov work lands.

The `Matrix` class added here is temporary. It is a lightweight CPU dense matrix used to prototype the small projected dense computations; in the final Uni20 shape this should become a type alias or thin adapter for a rank-2 tensor once that interface is ready.

## What changed

- Adds a reference LAPACK wrapper layer for the float/double dense routines needed by the current linalg prototypes.
- Adds a temporary CPU dense `Matrix` type and CPU matrix operation hooks.
- Adds dense matrix exponential support and coverage for real, complex, float, double, and extended host scalar paths where supported.
- Renames the backend tracing macro from `UNI20_API_CALL` to `UNI20_EXTERNAL_API_CALL` so LAPACK/BLAS calls are clearly marked as outgoing library calls.
- Exports LAPACK libraries through the backend link interface and adds a small `gesv` regression test so split BLAS/LAPACK installations are covered.
- Documents the new LAPACK backend layer in the backend architecture notes.

## Validation

- `git diff --check origin/main..HEAD`
- `cmake -S . -B ./build_codex/build_gcc13_debug_linalg_pr -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build ./build_codex/build_gcc13_debug_linalg_pr`
- `ctest --test-dir ./build_codex/build_gcc13_debug_linalg_pr --output-on-failure -R "LAPACKWrapper|MatrixExponential|CpuOps|BLAS_Wrapper"`
  - 57/57 passed
- `ctest --test-dir ./build_codex/build_gcc13_debug_linalg_pr --output-on-failure`
  - 539/539 passed
  - 1 skipped: `TbbNumaScheduler.RoundRobinScheduling`
