### PR TITLE
Add optional MPLAPACK binary128 backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,7 +638,7 @@ if(NOT UNI20_DOCS_WEB)
   add_library(uni20_deps INTERFACE)
   target_link_libraries(uni20_deps INTERFACE fmt::fmt)
   if(UNI20_ENABLE_MPLAPACK)
-    target_link_libraries(uni20_deps INTERFACE mplapack::mplapack_binary128)
+    target_link_libraries(uni20_deps INTERFACE mplapack::mpblas_binary128 mplapack::mplapack_binary128)
   endif()
 
   # Add subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,27 @@ option(UNI20_BUILD_PYTHON         "Build the Python bindings" ON)
 option(UNI20_BUILD_EXAMPLES       "Build the example programs" ON)
 option(UNI20_ENABLE_CUDA          "Enable CUDA backend support" OFF)
 option(UNI20_ENABLE_MPI           "Enable MPI support" OFF)
+option(UNI20_ENABLE_MPLAPACK      "Enable optional MPLAPACK binary128 integration probes" OFF)
+set(UNI20_HAS_FLOAT128 OFF)
+set(UNI20_FLOAT128_PROVIDER_MPLAPACK OFF)
+foreach(_uni20_removed_mplapack_cache_var IN ITEMS
+    UNI20_USE_SYSTEM_MPLAPACK
+    UNI20_MPLAPACK_GIT_REPOSITORY
+    UNI20_MPLAPACK_GIT_TAG
+    UNI20_MPLAPACK_SOURCE_DIR
+    UNI20_MPLAPACK_VERSION)
+  unset(${_uni20_removed_mplapack_cache_var} CACHE)
+endforeach()
+if(NOT UNI20_ENABLE_MPLAPACK)
+  foreach(_uni20_disabled_mplapack_cache_var IN ITEMS
+      UNI20_MPLAPACK_DIR
+      UNI20_MPLAPACK_SOURCE
+      UNI20_MPLAPACK_TARGET
+      UNI20_DETECTED_MPLAPACK
+      UNI20_MPLAPACK_BINARY128_HEADERS_COMPATIBLE)
+    unset(${_uni20_disabled_mplapack_cache_var} CACHE)
+  endforeach()
+endif()
 option(UNI20_BUILD_TESTS          "Build unit tests" ON)
 option(UNI20_BUILD_COMBINED_TESTS "Build combined test executable (in addition to per-module tests)" ON)
 option(UNI20_BUILD_BENCH          "Build benchmarks" ON)
@@ -124,6 +145,7 @@ if(UNI20_DOCS_WEB)
   set(UNI20_BUILD_PYTHON OFF CACHE BOOL "Build the Python bindings" FORCE)
   set(UNI20_BUILD_ASM OFF CACHE BOOL "Build stand-alone assembly dumps for snippets in asm/" FORCE)
   set(UNI20_ENABLE_CUDA OFF CACHE BOOL "Enable CUDA backend support" FORCE)
+  set(UNI20_ENABLE_MPLAPACK OFF CACHE BOOL "Enable optional MPLAPACK binary128 integration probes" FORCE)
 endif()
 
 if(UNI20_ENABLE_COVERAGE)
@@ -366,6 +388,98 @@ endif()
 if(NOT UNI20_DOCS_WEB)
   include(FetchContent)
 
+  if(UNI20_ENABLE_MPLAPACK)
+    find_package(mplapack QUIET CONFIG)
+    if(NOT mplapack_FOUND OR NOT TARGET mplapack::mpblas_binary128 OR NOT TARGET mplapack::mplapack_binary128)
+      message(FATAL_ERROR
+        "UNI20_ENABLE_MPLAPACK=ON requires an externally configured MPLAPACK binary128 package.\n"
+        "The package must provide targets mplapack::mpblas_binary128 and mplapack::mplapack_binary128.\n"
+        "See docs/mplapack_binary128_setup.md for the full setup and validation workflow.\n"
+        "\n"
+        "Build MPLAPACK separately, for example:\n"
+        "  cmake -S /path/to/mplapack -B /path/to/mplapack-build-binary128 \\\n"
+        "    -DCMAKE_BUILD_TYPE=Release \\\n"
+        "    -DMPLAPACK_CXX_STANDARD=23 \\\n"
+        "    -DMPLAPACK_CXX_EXTENSIONS=ON \\\n"
+        "    -DMPLAPACK_ENABLE_DOUBLE=OFF \\\n"
+        "    -DMPLAPACK_ENABLE_MPFR=OFF \\\n"
+        "    -DMPLAPACK_ENABLE_GMP=OFF \\\n"
+        "    -DMPLAPACK_ENABLE_QD=OFF \\\n"
+        "    -DMPLAPACK_ENABLE_DD=OFF \\\n"
+        "    -DMPLAPACK_ENABLE_BINARY80=OFF \\\n"
+        "    -DMPLAPACK_ENABLE_BINARY128=ON \\\n"
+        "    -DMPLAPACK_BUILD_EXAMPLES=OFF \\\n"
+        "    -DMPLAPACK_BUILD_TESTS=OFF \\\n"
+        "    -DMPLAPACK_BUILD_BENCHMARKS=OFF\n"
+        "  cmake --build /path/to/mplapack-build-binary128 --parallel\n"
+        "  cmake --install /path/to/mplapack-build-binary128 --prefix /path/to/mplapack-install\n"
+        "\n"
+        "Then configure Uni20 with either:\n"
+        "  cmake -S . -B /path/to/uni20-build -DUNI20_ENABLE_MPLAPACK=ON -Dmplapack_DIR=/path/to/mplapack-build-binary128\n"
+        "or, after installing MPLAPACK:\n"
+        "  cmake -S . -B /path/to/uni20-build -DUNI20_ENABLE_MPLAPACK=ON -DCMAKE_PREFIX_PATH=/path/to/mplapack-install")
+    endif()
+
+    include(CheckCXXSourceCompiles)
+    set(_uni20_saved_try_compile_target_type "${CMAKE_TRY_COMPILE_TARGET_TYPE}")
+    set(_uni20_saved_required_libraries "${CMAKE_REQUIRED_LIBRARIES}")
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+    set(CMAKE_REQUIRED_LIBRARIES mplapack::mpblas_binary128 mplapack::mplapack_binary128)
+    unset(UNI20_MPLAPACK_BINARY128_HEADERS_COMPATIBLE CACHE)
+    check_cxx_source_compiles(
+      [[
+        #include <complex>
+        #include <cmath>
+        #include <cstdlib>
+        #include <mpblas_binary128.h>
+        #include <mplapack_binary128.h>
+
+        #ifndef MPLAPACK_BINARY128_MODE
+        #error "MPLAPACK_BINARY128_MODE is not defined"
+        #endif
+
+        #if MPLAPACK_BINARY128_MODE == MPLAPACK_BINARY128_MODE_LDBL
+        #error "MPLAPACK binary128 aliases long double"
+        #endif
+
+        int main()
+        {
+          mplapack_binary128_t x = static_cast<mplapack_binary128_t>(1);
+          auto y = abs(x);
+          std::complex<mplapack_binary128_t> z{x, x};
+          auto a = abs(z);
+          auto b = sqrt(z);
+          (void)y;
+          (void)a;
+          (void)b;
+          return 0;
+        }
+      ]]
+      UNI20_MPLAPACK_BINARY128_HEADERS_COMPATIBLE)
+    set(CMAKE_REQUIRED_LIBRARIES "${_uni20_saved_required_libraries}")
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE "${_uni20_saved_try_compile_target_type}")
+    unset(_uni20_saved_required_libraries)
+    unset(_uni20_saved_try_compile_target_type)
+    if(NOT UNI20_MPLAPACK_BINARY128_HEADERS_COMPATIBLE)
+      message(FATAL_ERROR
+        "The found MPLAPACK package is not compatible with Uni20's C++23 binary128 build.\n"
+        "Build MPLAPACK separately with GNU++23, apply the local CMake detector patch if needed,\n"
+        "and point Uni20 at that build or install prefix. See docs/mplapack_binary128_setup.md.")
+    endif()
+
+    set(UNI20_MPLAPACK_SOURCE "package" CACHE STRING "Source type for mplapack" FORCE)
+    set(UNI20_MPLAPACK_TARGET "mplapack::mplapack_binary128" CACHE STRING "CMake target name for mplapack" FORCE)
+    if(DEFINED mplapack_DIR)
+      set(UNI20_MPLAPACK_DIR "${mplapack_DIR}" CACHE PATH "Install or build directory for mplapack" FORCE)
+      set(UNI20_DETECTED_MPLAPACK "Found via ${mplapack_DIR}" CACHE STRING "Found MPLAPACK package" FORCE)
+    else()
+      set(UNI20_DETECTED_MPLAPACK "Found package" CACHE STRING "Found MPLAPACK package" FORCE)
+    endif()
+    set(UNI20_HAS_FLOAT128 ON)
+    set(UNI20_FLOAT128_PROVIDER_MPLAPACK ON)
+    message(STATUS "MPLAPACK binary128 backend enabled: ${UNI20_DETECTED_MPLAPACK}")
+  endif()
+
   uni20_add_dependency(
     NAME fmt
     VERSION 8.1.1
@@ -523,6 +637,9 @@ if(NOT UNI20_DOCS_WEB)
   # Create an interface library for common dependencies
   add_library(uni20_deps INTERFACE)
   target_link_libraries(uni20_deps INTERFACE fmt::fmt)
+  if(UNI20_ENABLE_MPLAPACK)
+    target_link_libraries(uni20_deps INTERFACE mplapack::mplapack_binary128)
+  endif()
 
   # Add subdirectories
   add_subdirectory(src)

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@
 
 ## Krylov and Linear Algebra
 
+- [MPLAPACK Binary128 Setup](mplapack_binary128_setup.md)
 - [Krylov Algorithms](krylov_algorithms.md)
 - [Krylov Solver Defaults](krylov_solver_defaults.md)
 - [Krylov Precision Validation](krylov_precision_validation.md)

--- a/docs/krylov_algorithms.md
+++ b/docs/krylov_algorithms.md
@@ -13,14 +13,19 @@ the project scalar policy in [scalar_policy.md](scalar_policy.md):
 | `d` | `double` |
 | `c` | `uni20::complex<float>` |
 | `z` | `uni20::complex<double>` |
+| `f128` | optional `uni20::float128` |
+| `cf128` | optional `uni20::complex<uni20::float128>` |
 
-With `UNI20_ENABLE_MPLAPACK=ON`, the spike branch also has experimental real
-binary128 coverage for scalar-generic dense projected kernels, matrix-free
-eigensolvers, and exponential actions. Ordinary typed Krylov tests instantiate
-`uni20::float128` and `uni20::complex<uni20::float128>` in MPLAPACK-enabled
-builds; dedicated `MplapackBinary128*` tests cover precision-specific stress
-cases. This is not part of the stable s/d/c/z support matrix yet; see
-[mplapack_binary128_spike.md](mplapack_binary128_spike.md).
+With `UNI20_ENABLE_MPLAPACK=ON`, Uni20 enables optional experimental binary128
+probes for scalar-generic dense projected kernels, matrix-free eigensolvers, and
+exponential actions. MPLAPACK is an external package dependency in this
+configuration; Uni20 does not download or build it. The
+ordinary typed Krylov tests remain focused on the stable `s`, `d`, `c`, and `z`
+paths; dedicated `MplapackBinary128*` targets cover binary128-specific stress
+cases. The main inventory tables below therefore list the ordinary `s`, `d`,
+`c`, and `z` coverage, followed by a separate optional binary128 inventory. See
+[krylov_precision_validation.md](krylov_precision_validation.md) for the
+test-level `f128` and `cf128` validation matrix.
 
 ## Matrix-Free Boundary
 
@@ -146,8 +151,45 @@ These are local host-side kernels for small Krylov subspace matrices.
 | Real Schur selected subspace condition estimates | yes | yes | n/a | n/a | Dense projected real Schur block selection through LAPACK `trsen`, returning reciprocal eigenvalue-cluster and invariant-subspace condition estimates. |
 | Real Schur right eigenvectors | yes | yes | n/a | n/a | Dense projected real Schur eigenvector extraction through LAPACK `trevc`, unpacked into complex columns. |
 | Real Schur eigenpair condition estimates | yes | yes | n/a | n/a | Dense projected real Schur eigenvalue/eigenvector conditioning through LAPACK `trsna`. |
-| Complex nonsymmetric eigensystem | n/a | n/a | yes | yes | Arnoldi Ritz extraction in complex arithmetic; MPLAPACK-gated `complex<binary128>` is probed separately. |
-| Complex Schur factorization and reordering | n/a | n/a | yes | yes | Complex nonsymmetric implicit restart; MPLAPACK-gated `complex<binary128>` is probed separately. |
+| Complex nonsymmetric eigensystem | n/a | n/a | yes | yes | Arnoldi Ritz extraction in complex arithmetic. |
+| Complex Schur factorization and reordering | n/a | n/a | yes | yes | Complex nonsymmetric implicit restart. |
+
+### Optional MPLAPACK Binary128 Inventory
+
+These paths are available only when `UNI20_ENABLE_MPLAPACK=ON` and the
+configured MPLAPACK package provides a real binary128 type. This table records
+the intended scalar coverage of the optional binary128 surface; the separate
+precision-validation matrix records which rows have dedicated stress tests.
+
+At the native solver entry-point level, binary128 mostly mirrors the ordinary
+`s`, `d`, `c`, and `z` coverage: real paths have `f128` analogues, complex
+paths have `cf128` analogues, and Hermitian paths support both. The broad dense
+projected helper inventory is intentionally split from the default-facing
+headers where possible, but it remains in-tree and is tested by the gated
+`MplapackBinary128DenseSubspaceTest` target. These wrappers are early
+infrastructure for the future mdspan/rank-2 tensor layer, not a stable public
+API commitment.
+
+| component or entry point | `f128` | `cf128` | notes |
+| --- | --- | --- | --- |
+| Dense vector and matrix primitives | yes | yes | Scalar-generic Krylov host-side helpers. |
+| MPBLAS wrapper surface | yes | yes | Current wrapper surface covers projected `gemm`, `gemv`, rank-update, symmetric-rank, and Hermitian-rank operations used by active paths. |
+| Tensor/linalg CPU helper probes | yes | n/a | Current probes cover real one-norm accumulation and real dense solve. |
+| Broad dense projected real helper inventory | yes | n/a | Gated tests cover norms, dense/band/tridiagonal solves and diagnostics, SPD and symmetric-indefinite helpers, QR/LQ/QL/RQ, bidiagonal/SVD helpers, real symmetric/generalized symmetric eigensystems, and real nonsymmetric/Schur/QZ helpers. |
+| Dense projected complex eigensystem and Schur helper inventory | n/a | yes | Gated tests cover complex Hermitian/generalized Hermitian eigensystems, complex nonsymmetric eigensystems, and complex Schur/reordering. |
+| Symmetric tridiagonal projected eigensystem | yes | n/a | Uses MPLAPACK `Rsterf`/`Rsteqr`; this is the projected problem behind real and complex Hermitian Lanczos. |
+| Real nonsymmetric projected eigensystem and Schur kernels | yes | n/a | Active wrapper surface covers `Rgeev`, `Rgees`, `Rhseqr`, and `Rtrexc`. |
+| Complex nonsymmetric projected eigensystem and Schur kernels | n/a | yes | Active wrapper surface covers `Cgeev`, `Cgees`, and `Ctrexc`. |
+| `symmetric_lanczos_standard` | yes | yes | `f128` is directly probed; `cf128` follows the same real tridiagonal projected eigensystem path but does not yet have a dedicated binary128 stress test. |
+| `symmetric_lanczos_restarted_standard` | yes | yes | Templated path; no dedicated binary128 restart stress test yet. |
+| `symmetric_lanczos_restarted_transformed` | yes | yes | Templated transformed path; no dedicated binary128 stress test yet. |
+| `symmetric_lanczos_restarted_generalized_transformed` | yes | yes | Templated generalized transformed path; no dedicated binary128 stress test yet. |
+| `real_nonsymmetric_arnoldi_standard` | yes | n/a | Full-projection real binary128 Arnoldi is directly probed. |
+| `real_nonsymmetric_arnoldi_restarted_standard` | yes | n/a | Restarted path uses the active real Schur wrapper surface; no dedicated binary128 restart stress test yet. |
+| `complex_nonsymmetric_arnoldi_standard` | n/a | yes | Full-projection complex binary128 Arnoldi is directly probed; restart uses the active complex Schur wrapper surface. |
+| `hermitian_krylov_exponential_action` | yes | yes | `f128` is directly probed; `cf128` uses the binary128 complex dense exponential instantiations but does not yet have a dedicated stress test. |
+| `nonsymmetric_krylov_exponential_action` | yes | yes | Templated path backed by binary128 real and complex dense exponential instantiations; no dedicated binary128 stress test yet. |
+| `taylor_exponential_action` | yes | yes | Scalar-generic validation path; no dedicated binary128 stress test yet. |
 
 ### Symmetric And Hermitian Lanczos
 

--- a/docs/krylov_precision_validation.md
+++ b/docs/krylov_precision_validation.md
@@ -14,37 +14,42 @@ tuning values, see [krylov_algorithms.md](krylov_algorithms.md).
 | `d` | `double` |
 | `c` | `uni20::complex<float>` |
 | `z` | `uni20::complex<double>` |
+| `f128` | `uni20::float128`, when `UNI20_HAS_FLOAT128=1` |
+| `cf128` | `uni20::complex<uni20::float128>`, also spelled `uni20::complex256`, when `UNI20_HAS_FLOAT128=1` |
 
 Experimental binary128 validation is gated by `UNI20_ENABLE_MPLAPACK=ON` and
-is tracked separately in
-[mplapack_binary128_spike.md](mplapack_binary128_spike.md). It currently covers
-selected dense projected kernels plus real and complex matrix-free eigensolver,
-projected exponential-action, Taylor validation, and TDVP Matrix Market stress
-paths. The gated probe also checks that selected scalar-generic helpers use
-Uni20's real scalar traits rather than relying only on `std::floating_point`.
+requires an external MPLAPACK package configured with the binary128 backend.
+Uni20 does not download or build MPLAPACK. The optional validation currently
+covers scalar aliases and I/O, BLAS/LAPACK wrapper surfaces, tensor linear
+algebra probes, broad dense projected helper coverage, real and complex
+matrix-free eigensolvers, and projected exponential action. The gated probes
+also check that selected scalar-generic helpers use Uni20's real scalar traits
+rather than relying only on `std::floating_point`.
 
 Most ordinary Krylov tests are typed through
 `tests/krylov/krylov_test_types.hpp`. In a normal build those aliases expand to
-the `s`, `d`, `c`, and `z` paths. In an MPLAPACK-enabled build they also include
-configured `uni20::float128` and `uni20::complex<uni20::float128>` where the
-algorithm is scalar-generic. The `MplapackBinary128*` tests remain for
-precision-specific stress cases such as below-double gaps, tiny pivots,
-underflow-sensitive residuals, and TDVP Matrix Market exponential diagnostics.
+the `s`, `d`, `c`, and `z` paths. The MPLAPACK-enabled binary128 coverage is
+kept in separate `MplapackBinary128*` targets. The broad dense-subspace wrappers
+are retained and tested there, but are not pulled into the ordinary typed solver
+matrix.
 
 ## Native Solver Coverage
+
+This table records the ordinary default-build coverage for `s`, `d`, `c`, and
+`z`. Optional binary128 probes are listed separately below.
 
 | algorithm | `s` | `d` | `c` | `z` | tests |
 | --- | --- | --- | --- | --- | --- |
 | Dense vector/matrix primitives | yes | yes | yes | yes | `KrylovDenseLinalgTypedTest` |
-| Dense real matrix norms | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.ComputesDenseReal*MatrixNorms`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.*MatrixNorm*` |
+| Dense real matrix norms | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.ComputesDenseReal*MatrixNorms` |
 | Dense matrix exponential, including complex multipliers | yes | yes | yes | yes | `MatrixExponentialTypedTest`, `MatrixExponentialTest.RealMatrixWithComplexMultiplierPromotesToComplex`, `MatrixExponentialTest.ComplexMatrixWithComplexMultiplierUsesComplexTime` |
 | Dense real linear solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseRealLinearSystemWithPivoting` |
 | Dense real refined linear solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.RefinesDenseRealLinearSystemWithDiagnostics` |
 | Dense real expert linear solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseRealExpertLinearSystemWithDiagnostics` |
 | Dense real equilibration | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.ComputesDenseRealEquilibration` |
 | Dense real LU factorization and solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesFromDenseRealLuFactorization` |
-| Dense real general-band norm, equilibration, solve, refined/expert solve, and condition estimate | yes | yes | n/a | n/a | MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.GeneralBand*` |
-| Dense real general tridiagonal solve, condition, and refinement | yes | yes | n/a | n/a | MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.GeneralTridiagonal*` |
+| Dense real general-band norm, equilibration, solve, refined/expert solve, and condition estimate | yes | yes | n/a | n/a | ordinary `s`/`d` dense-subspace tests; binary128 coverage is listed in the optional table below |
+| Dense real general tridiagonal solve, condition, and refinement | yes | yes | n/a | n/a | ordinary `s`/`d` dense-subspace tests; binary128 coverage is listed in the optional table below |
 | Dense real reciprocal condition estimate | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.EstimatesDenseRealReciprocalConditionNumber` |
 | Dense real triangular solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseRealTriangularSystem` |
 | Dense real triangular refined solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.RefinesDenseRealTriangularSystemWithDiagnostics` |
@@ -58,8 +63,8 @@ underflow-sensitive residuals, and TDVP Matrix Market exponential diagnostics.
 | Dense real rank-revealing least-squares solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseRankRevealingLeastSquaresProblem` |
 | Dense real symmetric positive definite solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseSymmetricPositiveDefiniteSystem` |
 | Dense real symmetric positive definite factorization and solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseSymmetricPositiveDefiniteSystemFromFactorization` |
-| Dense real symmetric positive definite band solve, condition, and refinement | yes | yes | n/a | n/a | MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.SymmetricPositiveDefiniteBand*` |
-| Dense real symmetric positive definite tridiagonal solve, condition, and refinement | yes | yes | n/a | n/a | MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.SymmetricPositiveDefiniteTridiagonal*` |
+| Dense real symmetric positive definite band solve, condition, and refinement | yes | yes | n/a | n/a | ordinary `s`/`d` dense-subspace tests; binary128 coverage is listed in the optional table below |
+| Dense real symmetric positive definite tridiagonal solve, condition, and refinement | yes | yes | n/a | n/a | ordinary `s`/`d` dense-subspace tests; binary128 coverage is listed in the optional table below |
 | Dense real symmetric positive definite refined solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.RefinesDenseSymmetricPositiveDefiniteSystemWithDiagnostics` |
 | Dense real symmetric positive definite expert solve | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseSymmetricPositiveDefiniteExpertSystemWithDiagnostics` |
 | Dense real symmetric positive definite equilibration | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.ComputesDenseSymmetricPositiveDefiniteEquilibration` |
@@ -103,12 +108,12 @@ underflow-sensitive residuals, and TDVP Matrix Market exponential diagnostics.
 | Dense generalized real symmetric eigensystem | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseGeneralizedRealSymmetricEigenvectors` |
 | Dense generalized real divide-and-conquer symmetric eigensystem | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesDenseGeneralizedRealSymmetricDivideAndConquerEigenvectors` |
 | Dense generalized real selected symmetric eigensystem | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesSelectedDenseGeneralizedRealSymmetricEigenvectors` |
-| Dense complex Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesDenseComplexHermitianEigenvectors`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.ComplexHermitianEigensystemResolvesGapBelowDoublePrecision` |
-| Dense complex divide-and-conquer Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesDenseComplexHermitianDivideAndConquerEigenvectors`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.ComplexHermitianDivideAndConquerEigensystemResolvesGapBelowDoublePrecision` |
-| Dense complex selected Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesSelectedDenseComplexHermitianEigenvectors`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.SelectedComplexHermitianEigensystemResolvesGapBelowDoublePrecision` |
-| Dense generalized complex Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesDenseGeneralizedComplexHermitianEigenvectors`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.ComplexGeneralizedHermitianEigensystemResolvesMetricGapBelowDoublePrecision` |
-| Dense generalized complex divide-and-conquer Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesDenseGeneralizedComplexHermitianDivideAndConquerEigenvectors`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.ComplexGeneralizedHermitianDivideAndConquerEigensystemResolvesMetricGapBelowDoublePrecision` |
-| Dense generalized complex selected Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesSelectedDenseGeneralizedComplexHermitianEigenvectors`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.SelectedComplexGeneralizedHermitianEigensystemResolvesMetricGapBelowDoublePrecision` |
+| Dense complex Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesDenseComplexHermitianEigenvectors` |
+| Dense complex divide-and-conquer Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesDenseComplexHermitianDivideAndConquerEigenvectors` |
+| Dense complex selected Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesSelectedDenseComplexHermitianEigenvectors` |
+| Dense generalized complex Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesDenseGeneralizedComplexHermitianEigenvectors` |
+| Dense generalized complex divide-and-conquer Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesDenseGeneralizedComplexHermitianDivideAndConquerEigenvectors` |
+| Dense generalized complex selected Hermitian eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesSelectedDenseGeneralizedComplexHermitianEigenvectors` |
 | Dense symmetric tridiagonal eigensystem | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesSymmetricTridiagonal*` |
 | Dense real nonsymmetric eigensystem | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesRealNonsymmetric*` |
 | Dense real nonsymmetric expert eigensystem | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SolvesRealNonsymmetricExpertEigenvectorsWithDiagnostics` |
@@ -128,8 +133,8 @@ underflow-sensitive residuals, and TDVP Matrix Market exponential diagnostics.
 | Dense real Schur selected subspace condition estimates | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.SelectsRealSchurSubspaceWithConditionEstimates` |
 | Dense real Schur right eigenvectors | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.ComputesRealSchurRightEigenvectors` |
 | Dense real Schur eigenpair condition estimates | yes | yes | n/a | n/a | `KrylovDenseSubspaceTypedTest.EstimatesRealSchurEigenpairConditioning` |
-| Dense complex nonsymmetric eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesComplexNonsymmetricEigenvalues`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.ComplexNonsymmetricEigensystemResolvesGapBelowDoublePrecision` |
-| Dense complex Schur and reordering | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.ComputesComplexSchur*`, `ReordersComplexSchur*`; MPLAPACK-gated `MplapackBinary128DenseSubspaceTest.ComplexSchur*` |
+| Dense complex nonsymmetric eigensystem | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.SolvesComplexNonsymmetricEigenvalues` |
+| Dense complex Schur and reordering | n/a | n/a | yes | yes | `KrylovDenseSubspaceComplexTypedTest.ComputesComplexSchur*`, `ReordersComplexSchur*` |
 | Symmetric/Hermitian Lanczos, full projection | yes | yes | yes | yes | `KrylovSymmetricLanczosRealTypedTest.SolvesDiagonalLargestAlgebraicProblem`, `KrylovHermitianLanczosComplexTypedTest.SolvesImaginaryOffDiagonalHermitianProblem` |
 | Symmetric/Hermitian Lanczos, restarted regular mode | yes | yes | yes | yes | `KrylovSymmetricLanczosRealTypedTest.RestartedSolveConvergesOnDiagonalLargestAlgebraicProblem`, `KrylovHermitianLanczosComplexTypedTest.RestartedSolveConvergesOnPhaseTwistedLaplacian` |
 | Symmetric/Hermitian Lanczos, transformed shift-invert mapping | yes | yes | yes | yes | `KrylovSymmetricLanczosRealTypedTest.ShiftInvertSmallestAlgebraicSelectorActsInTransformedSpace`, `KrylovHermitianLanczosComplexTypedTest.ShiftInvertSelectorMapsComplexHermitianVectorPath` |
@@ -143,10 +148,43 @@ underflow-sensitive residuals, and TDVP Matrix Market exponential diagnostics.
 | Taylor exponential action, scaled Taylor validation path | yes | yes | yes | yes | `KrylovExponentialRealTypedTest.TaylorActionMatchesDiagonalExponential`, `KrylovExponentialRealTypedTest.TaylorActionMatchesJordanExponential`, `KrylovExponentialComplexTypedTest.TaylorActionAcceptsComplexTime`, `KrylovExponentialComplexTypedTest.TaylorZeroVectorReturnsZeroWithoutMatvec`, `KrylovExponentialTaylorAction.ThrowsWhenTaylorDegreeCannotMeetTolerance` |
 | Lanczos-vs-Taylor exponential probe example | yes | yes | yes | yes | `KrylovExponentialProbeExample.Float`, `KrylovExponentialProbeExample.Double` |
 | Lanczos exponential orthogonality-floor example | yes | yes | n/a | n/a | `KrylovExponentialOrthogonalityExample.Float` |
-| TDVP Matrix Market exponential probe example | n/a | n/a | yes | yes | `KrylovExponentialMatrixMarketProbeExample.TdvpFloat`, `KrylovExponentialMatrixMarketProbeExample.TdvpDouble`; MPLAPACK-gated `MplapackBinary128KrylovSolversTest.TdvpMatrixMarketExponentialExposesOldTailCriterion` |
+| TDVP Matrix Market exponential probe example | n/a | n/a | yes | yes | `KrylovExponentialMatrixMarketProbeExample.TdvpFloat`, `KrylovExponentialMatrixMarketProbeExample.TdvpDouble` |
 
 `DenseHostVectorOps` also has compile-time `KrylovMatrixFreeOperator` assertions
 for `s`, `d`, `c`, and `z`.
+
+## Optional MPLAPACK Binary128 Coverage
+
+This table records the `UNI20_ENABLE_MPLAPACK=ON` probes. The entries are not
+part of the ordinary default test matrix. They check that the scalar-generic
+paths genuinely operate at the configured binary128 precision and do not
+silently collapse to double precision.
+
+The native solver entry points are intended to mirror the ordinary precision
+coverage where the scalar category makes sense: real solver paths gain `f128`,
+complex solver paths gain `cf128`, and Hermitian paths gain both. The dense
+projected helper inventory is intentionally broader than the active solver
+surface: wrappers that are not used by current solvers are split out of the
+default-facing headers where possible, but remain in-tree and tested.
+
+| algorithm or surface | `f128` | `cf128` | tests |
+| --- | --- | --- | --- |
+| Scalar aliases, numeric limits, scalar concepts, and scalar I/O | yes | yes | `MplapackBinary128Test.Uni20NumericLimitsSeesBackendScalar`, `Uni20ScalarConceptsSeeBackendScalar`, `Uni20ScalarIo*` |
+| MPBLAS wrapper surface | yes | yes | `MplapackBinary128Test.LinksMpblasTransitively`, `Uni20BlasWrappersPreserveBinary128OnlyIncrements` |
+| Tensor one-norm and dense linear solve through linalg CPU helpers | yes | n/a | `MplapackBinary128CpuOpsTest.TensorMatrixOneNormPreservesBinary128Accumulation`, `TensorSolveAcceptsPivotsBelowDoubleMinimum` |
+| Broad dense projected real helper inventory | yes | n/a | `MplapackBinary128DenseSubspaceTest.*` real rows: norms, dense/band/tridiagonal solves, SPD and symmetric-indefinite solves, factorizations, SVD, symmetric/generalized symmetric eigensystems, real Schur/QZ, and condition diagnostics |
+| Dense projected complex eigensystem and Schur helper inventory | n/a | yes | `MplapackBinary128DenseSubspaceTest.Complex*` rows for Hermitian/generalized Hermitian, nonsymmetric eigensystem, Schur, and Schur reordering |
+| Symmetric tridiagonal projected eigensystem | yes | n/a | `MplapackBinary128KrylovSolversTest.TridiagonalProjectionResolvesGapBelowDoublePrecision` |
+| Symmetric/Hermitian Lanczos, full projection | yes | no | `MplapackBinary128KrylovSolversTest.SymmetricLanczosResolvesDiagonalGapBelowDoublePrecision` |
+| Real nonsymmetric projected Schur kernels | yes | n/a | `MplapackBinary128KrylovSolversTest.RealSchurAndReorderUseBinary128ProjectedLAPACK`, `RealHessenbergSchurUsesBinary128ProjectedLAPACK` |
+| Real nonsymmetric Arnoldi, full projection | yes | n/a | `MplapackBinary128KrylovSolversTest.RealArnoldiResolvesTriangularGapBelowDoublePrecision` |
+| Complex nonsymmetric projected Schur kernels | n/a | yes | `MplapackBinary128KrylovSolversTest.ComplexSchurAndReorderUseBinary128ProjectedLAPACK` |
+| Complex nonsymmetric Arnoldi, full projection | n/a | yes | `MplapackBinary128KrylovSolversTest.ComplexArnoldiResolvesComplexGapBelowDoublePrecision` |
+| Hermitian Krylov exponential action, fixed subspace | yes | no | `MplapackBinary128KrylovSolversTest.HermitianExponentialActionPreservesBinary128OnlyIncrement` |
+
+`no` in this optional table means no dedicated binary128 probe exists yet. It
+does not necessarily mean the templated implementation cannot instantiate once
+the corresponding dense projected kernel and matrix-free operation are covered.
 
 ## External ARPACK Oracle Coverage
 

--- a/docs/mplapack_binary128_setup.md
+++ b/docs/mplapack_binary128_setup.md
@@ -1,0 +1,156 @@
+# MPLAPACK Binary128 Setup
+
+Uni20 can optionally use MPLAPACK as an experimental binary128 backend for
+selected scalar, dense projected linear algebra, Krylov, and exponential-action
+tests. This is an opt-in developer configuration. Uni20 does not download or
+build MPLAPACK during its own configure step.
+
+The recommended workflow is:
+
+1. Build MPLAPACK once as a separate GNU++23 package with only the binary128
+   backend enabled.
+2. Install that package into a local prefix.
+3. Configure Uni20 with `UNI20_ENABLE_MPLAPACK=ON` and point CMake at the
+   installed MPLAPACK package.
+
+## Build MPLAPACK
+
+From a Uni20 checkout with an MPLAPACK checkout next to it:
+
+```bash
+git -C ../mplapack apply "$PWD/docs/patches/mplapack-cmake-binary128-detection.patch"
+```
+
+This carries Uni20's current local MPLAPACK compatibility patch. If the patch no
+longer applies, inspect the upstream MPLAPACK changes before continuing; it may
+mean the issue has been fixed differently.
+
+```bash
+cmake -S ../mplapack -B ./build_codex/mplapack_binary128 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PWD/build_codex/mplapack_binary128_install" \
+  -DMPLAPACK_CXX_STANDARD=23 \
+  -DMPLAPACK_CXX_EXTENSIONS=ON \
+  -DMPLAPACK_ENABLE_DOUBLE=OFF \
+  -DMPLAPACK_ENABLE_MPFR=OFF \
+  -DMPLAPACK_ENABLE_GMP=OFF \
+  -DMPLAPACK_ENABLE_QD=OFF \
+  -DMPLAPACK_ENABLE_DD=OFF \
+  -DMPLAPACK_ENABLE_BINARY80=OFF \
+  -DMPLAPACK_ENABLE_BINARY128=ON \
+  -DMPLAPACK_BUILD_EXAMPLES=OFF \
+  -DMPLAPACK_BUILD_TESTS=OFF \
+  -DMPLAPACK_BUILD_BENCHMARKS=OFF
+
+cmake --build ./build_codex/mplapack_binary128 --parallel
+cmake --install ./build_codex/mplapack_binary128
+```
+
+The configure output should report a real binary128 backend, for example:
+
+```text
+binary128: _Float128 + strfromf128
+MPLAPACK_HAVE_STD_ABS_FLOAT128=1
+MPLAPACK_HAVE_STD_MATH_FLOAT128=1
+MPLAPACK_HAVE_STD_COMPLEX_FLOAT128=1
+```
+
+## Configure Uni20
+
+Use the installed MPLAPACK prefix:
+
+```bash
+cmake -S . -B ./build_codex/build_gcc13_debug_mplapack \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DUNI20_ENABLE_MPLAPACK=ON \
+  -DCMAKE_PREFIX_PATH="$PWD/build_codex/mplapack_binary128_install"
+```
+
+Pointing directly at the MPLAPACK build tree also works while developing
+MPLAPACK itself:
+
+```bash
+cmake -S . -B ./build_codex/build_gcc13_debug_mplapack \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DUNI20_ENABLE_MPLAPACK=ON \
+  -Dmplapack_DIR="$PWD/build_codex/mplapack_binary128"
+```
+
+The package must provide both CMake targets:
+
+```text
+mplapack::mpblas_binary128
+mplapack::mplapack_binary128
+```
+
+## Validate
+
+Build and run the MPLAPACK-gated Uni20 probes:
+
+```bash
+cmake --build ./build_codex/build_gcc13_debug_mplapack --parallel 36 \
+  --target \
+    uni20_mplapack_binary128_tests \
+    uni20_linalg_mplapack_binary128_tests \
+    uni20_krylov_mplapack_binary128_tests
+
+ctest --test-dir ./build_codex/build_gcc13_debug_mplapack \
+  --output-on-failure \
+  --parallel 36 \
+  -R "MplapackBinary128"
+```
+
+## Carried Local MPLAPACK Patch
+
+On 2026-06-30, upstream MPLAPACK master configured and built correctly with
+GCC 13.3 through the autoconf path in GNU++23 mode. The resulting installed
+headers also compile cleanly from Uni20's strict C++23 translation units.
+
+The CMake path needed one local patch:
+[patches/mplapack-cmake-binary128-detection.patch](patches/mplapack-cmake-binary128-detection.patch).
+It makes the CMake binary128 detector match the newer autoconf checks by:
+
+- probing `std::abs(_Float128)` in `_Float128` mode instead of
+  `std::abs(__float128)`;
+- exporting `MPLAPACK_HAVE_STD_MATH_FLOAT128`;
+- exporting `MPLAPACK_HAVE_STD_COMPLEX_FLOAT128`;
+- exporting `MPLAPACK_HAVE_C_COMPLEX_FLOAT128`.
+
+Without that patch, an older CMake detector can suppress MPLAPACK's `_Float128`
+fallbacks based on `__float128` support and then fail in generated LAPACK
+sources such as `Rlaexc.cpp` and `Rlagts.cpp` with errors like:
+
+```text
+no matching function for call to 'max(__float128, __float128, __float128, __float128)'
+```
+
+Do not build MPLAPACK for Uni20 in GNU++17 mode. Current upstream autoconf and
+the patched CMake detector both build successfully in GNU++17 mode, but the
+installed headers record GNU++17 feature-test results. When those headers are
+later consumed from Uni20's C++23 build, the fallback global
+`abs(_Float128)` overload conflicts with libstdc++'s C++23
+`std::abs(_Float128)` overloads. Building MPLAPACK itself as GNU++23 avoids
+that mismatch.
+
+## Troubleshooting
+
+If Uni20 cannot find MPLAPACK, check the package path:
+
+```bash
+find ./build_codex/mplapack_binary128_install -name mplapackConfig.cmake
+```
+
+Then pass either the install prefix through `CMAKE_PREFIX_PATH` or the directory
+containing `mplapackConfig.cmake` through `mplapack_DIR`.
+
+If Uni20 configures but binary128 wrappers are disabled or tests are skipped,
+inspect the generated MPLAPACK configuration:
+
+```bash
+rg "MPLAPACK_BINARY128_MODE" \
+  ./build_codex/mplapack_binary128/include/mplapack_config.h \
+  ./build_codex/mplapack_binary128_install/include/mplapack/mplapack_config.h
+```
+
+For the current Uni20 probes, `MPLAPACK_BINARY128_MODE_LDBL` is not useful; use
+a real binary128 mode such as `_Float128` or quadmath.

--- a/docs/patches/mplapack-cmake-binary128-detection.patch
+++ b/docs/patches/mplapack-cmake-binary128-detection.patch
@@ -1,0 +1,81 @@
+diff --git a/cmake/MplapackDetectBinary128.cmake b/cmake/MplapackDetectBinary128.cmake
+index ad5f5e167..6cc19ca53 100644
+--- a/cmake/MplapackDetectBinary128.cmake
++++ b/cmake/MplapackDetectBinary128.cmake
+@@ -13,6 +13,9 @@
+ #   MPLAPACK_BINARY128_IO    (0 NONE / 1 SNPRINTF_LDBL / 2 STRFROMF128 / 3 QUADMATH_SNPRINTF)
+ #   MPLAPACK_BINARY128_MATH  (0 NONE / 1 LDBL / 2 F128 / 3 QUADMATH)
+ #   MPLAPACK_HAVE_STD_ABS_FLOAT128
++#   MPLAPACK_HAVE_STD_MATH_FLOAT128
++#   MPLAPACK_HAVE_STD_COMPLEX_FLOAT128
++#   MPLAPACK_HAVE_C_COMPLEX_FLOAT128
+ #   MPLAPACK_BINARY128_EXTRA_LIBS / MPLAPACK_BINARY128_EXTRA_FLAGS
+ #
+ # Priority follows configure.ac: _Float128 > __float128+quadmath > long double.
+@@ -41,6 +44,9 @@ set(MPLAPACK_BINARY128_MODE 0)
+ set(MPLAPACK_BINARY128_IO 0)
+ set(MPLAPACK_BINARY128_MATH 0)
+ set(MPLAPACK_HAVE_STD_ABS_FLOAT128 0)
++set(MPLAPACK_HAVE_STD_MATH_FLOAT128 0)
++set(MPLAPACK_HAVE_STD_COMPLEX_FLOAT128 0)
++set(MPLAPACK_HAVE_C_COMPLEX_FLOAT128 0)
+ set(MPLAPACK_BINARY128_EXTRA_LIBS "")
+ set(MPLAPACK_BINARY128_EXTRA_FLAGS "")
+ 
+@@ -152,12 +158,30 @@ if(NOT _configured)
+                       "Use GCC, or pass -DMPLAPACK_ENABLE_BINARY128=OFF.")
+ endif()
+ 
+-# std::abs(__float128) availability (gnu++17 extension on older GCC).
++# std::abs() availability for the selected binary128 scalar type.
+ set(_mp_std_abs 0)
+-if(_mp_have_q128)
++if(_mode EQUAL 2 AND _mp_have_f128)
++  _mp_try(_mp_std_abs "#include <cmath>\nint main(){ auto p=static_cast<_Float128(*)(_Float128)>(&std::abs); (void)p; return 0; }")
++elseif(_mode EQUAL 3 AND _mp_have_q128)
+   _mp_try(_mp_std_abs "#include <cmath>\nint main(){ auto p=static_cast<__float128(*)(__float128)>(&std::abs); (void)p; return 0; }")
+ endif()
+ 
++# std::_Float128 scalar math overload availability. Keep this separate from
++# std::abs(): libstdc++ exposes these overloads on a different schedule.
++set(_mp_std_math 0)
++if(_mode EQUAL 2)
++  _mp_try(_mp_std_math "#include <cmath>\n#include <type_traits>\nint main(){ _Float128 x=(_Float128)1.0; _Float128 y=(_Float128)2.0; static_assert(std::is_same<decltype(std::sin(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::sinh(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::cos(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::cosh(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::atan2(x,y)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::exp(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::log(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::log10(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::log2(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::pow(x,y)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::sqrt(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::ceil(x)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::nextafter(x,y)),_Float128>::value,\"\"); static_assert(std::is_same<decltype(std::ldexp(x,1)),_Float128>::value,\"\"); return 0; }")
++endif()
++
++# Complex _Float128 math availability for installed headers. Prefer the C++
++# overloads when available; otherwise use C _Float128 _Complex functions.
++set(_mp_std_complex 0)
++set(_mp_c_complex 0)
++if(_mode EQUAL 2)
++  _mp_try(_mp_std_complex "#include <complex>\nint main(){ std::complex<_Float128> z((_Float128)1.0,(_Float128)2.0); volatile _Float128 a=std::abs(z); (void)a; (void)std::sqrt(z); (void)std::sin(z); (void)std::cos(z); (void)std::exp(z); (void)std::log(z); return 0; }")
++  _mp_try(_mp_c_complex "#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__\n#define __STDC_WANT_IEC_60559_TYPES_EXT__ 1\n#endif\n#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__\n#define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1\n#endif\n#include <complex.h>\nint main(){ _Float128 _Complex z; __real__(z)=(_Float128)1.0; __imag__(z)=(_Float128)2.0; volatile _Float128 a=cabsf128(z); (void)a; (void)csqrtf128(z); (void)csinf128(z); (void)ccosf128(z); (void)cexpf128(z); (void)clogf128(z); return 0; }")
++endif()
++
+ # Export results. (This module is include()'d, so it shares the caller's scope;
+ # plain set() — not PARENT_SCOPE — publishes to the top-level CMakeLists.)
+ set(MPLAPACK_HAVE__FLOAT128 ${_mp_have_f128})
+@@ -171,6 +195,9 @@ set(MPLAPACK_BINARY128_MODE ${_mode})
+ set(MPLAPACK_BINARY128_IO ${_io})
+ set(MPLAPACK_BINARY128_MATH ${_math})
+ set(MPLAPACK_HAVE_STD_ABS_FLOAT128 ${_mp_std_abs})
++set(MPLAPACK_HAVE_STD_MATH_FLOAT128 ${_mp_std_math})
++set(MPLAPACK_HAVE_STD_COMPLEX_FLOAT128 ${_mp_std_complex})
++set(MPLAPACK_HAVE_C_COMPLEX_FLOAT128 ${_mp_c_complex})
+ 
+ # Backend link/compile needs: QUADMATH mode requires -lquadmath.
+ if(_mode EQUAL 3)
+diff --git a/cmake/mplapack_config.h.in b/cmake/mplapack_config.h.in
+index 50a706786..834e127ff 100644
+--- a/cmake/mplapack_config.h.in
++++ b/cmake/mplapack_config.h.in
+@@ -53,6 +53,9 @@
+ #define MPLAPACK_BINARY128_MATH  @MPLAPACK_BINARY128_MATH@
+ 
+ #define MPLAPACK_HAVE_STD_ABS_FLOAT128 @MPLAPACK_HAVE_STD_ABS_FLOAT128@
++#define MPLAPACK_HAVE_STD_MATH_FLOAT128 @MPLAPACK_HAVE_STD_MATH_FLOAT128@
++#define MPLAPACK_HAVE_STD_COMPLEX_FLOAT128 @MPLAPACK_HAVE_STD_COMPLEX_FLOAT128@
++#define MPLAPACK_HAVE_C_COMPLEX_FLOAT128 @MPLAPACK_HAVE_C_COMPLEX_FLOAT128@
+ 
+ /* ----------------------------------------------------------------------- */
+ /* Detected binary80 capabilities                                          */

--- a/docs/scalar_policy.md
+++ b/docs/scalar_policy.md
@@ -22,6 +22,12 @@ configuration it aliases `mplapack_binary128_t`, whose concrete spelling is
 selected by the installed MPLAPACK package. Code that is not gated by
 `UNI20_HAS_FLOAT128` must not name `uni20::float128`.
 
+To enable this path, build MPLAPACK separately with its binary128 backend and
+then point Uni20 at the resulting CMake package. Uni20 deliberately does not
+download or build MPLAPACK as part of its own configure step. See
+[MPLAPACK Binary128 Setup](mplapack_binary128_setup.md) for the exact package
+build, install, Uni20 configure, and validation commands.
+
 `uni20::complex<T>` is intentionally a type alias to `std::complex<T>`, not a
 replacement class. This keeps standard-library ABI, layout expectations, and
 interop behavior unchanged while giving Uni20 a single project-level spelling

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,7 @@ Primary CMake options:
 | `UNI20_BUILD_TESTS` | `ON` | Build and register C++ tests |
 | `UNI20_BUILD_COMBINED_TESTS` | `ON` | Build `tests/uni20_tests` combined test executable |
 | `UNI20_BUILD_PYTHON` | `ON` | Also enable `tests/python` CTest entries |
+| `UNI20_ENABLE_MPLAPACK` | `OFF` | Build optional binary128 probes; requires an external MPLAPACK package with `mplapack::mpblas_binary128` and `mplapack::mplapack_binary128` |
 
 Example configure:
 
@@ -52,6 +53,17 @@ To disable tests:
 
 ```bash
 cmake -S . -B build -DUNI20_BUILD_TESTS=OFF
+```
+
+To enable the optional MPLAPACK binary128 probes, configure MPLAPACK separately
+and point Uni20 at the resulting CMake package. See
+[MPLAPACK Binary128 Setup](mplapack_binary128_setup.md) for the full package
+build and validation workflow:
+
+```bash
+cmake -S . -B build \
+  -DUNI20_ENABLE_MPLAPACK=ON \
+  -Dmplapack_DIR=/path/to/mplapack-build-binary128
 ```
 
 ## Building Tests

--- a/src/uni20/backend/blas/backend_blas.hpp
+++ b/src/uni20/backend/blas/backend_blas.hpp
@@ -24,3 +24,7 @@
 #if UNI20_BACKEND_OPENBLAS
 #include <uni20/backend/blas/openblas/backend_openblas.hpp>
 #endif
+
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
+#include <uni20/backend/blas/mplapack_binary128.hpp>
+#endif

--- a/src/uni20/backend/blas/mplapack_binary128.hpp
+++ b/src/uni20/backend/blas/mplapack_binary128.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+/**
+ * \file mplapack_binary128.hpp
+ * \ingroup backend_blas
+ * \brief MPBLAS binary128 overloads for the Uni20 BLAS wrapper surface.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/config.hpp>
+#include <uni20/core/types.hpp>
+
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
+#include <mplapack_config.h>
+#endif
+
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK && defined(MPLAPACK_BINARY128_MODE) &&                      \
+    (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
+#include <mpblas_binary128.h>
+
+namespace uni20::blas
+{
+
+namespace mplapack_binary128_detail
+{
+
+inline char const* char_string(char value, char (&buffer)[2])
+{
+  buffer[0] = value;
+  buffer[1] = '\0';
+  return buffer;
+}
+
+} // namespace mplapack_binary128_detail
+
+inline void gemm(char transa, char transb, blas_int m, blas_int n, blas_int k, uni20::float128 alpha,
+                 uni20::float128 const* A, blas_int lda, uni20::float128 const* B, blas_int ldb, uni20::float128 beta,
+                 uni20::float128* C, blas_int ldc)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Rgemm, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+  char transa_string[2]{};
+  char transb_string[2]{};
+  Rgemm(mplapack_binary128_detail::char_string(transa, transa_string),
+        mplapack_binary128_detail::char_string(transb, transb_string), static_cast<mplapackint>(m),
+        static_cast<mplapackint>(n), static_cast<mplapackint>(k), alpha, const_cast<uni20::float128*>(A),
+        static_cast<mplapackint>(lda), const_cast<uni20::float128*>(B), static_cast<mplapackint>(ldb), beta, C,
+        static_cast<mplapackint>(ldc));
+}
+
+inline void gemv(char trans, blas_int m, blas_int n, uni20::float128 alpha, uni20::float128 const* A, blas_int lda,
+                 uni20::float128 const* x, blas_int incx, uni20::float128 beta, uni20::float128* y, blas_int incy)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Rgemv, trans, m, n, alpha, A, lda, x, incx, beta, y, incy);
+  char trans_string[2]{};
+  Rgemv(mplapack_binary128_detail::char_string(trans, trans_string), static_cast<mplapackint>(m),
+        static_cast<mplapackint>(n), alpha, const_cast<uni20::float128*>(A), static_cast<mplapackint>(lda),
+        const_cast<uni20::float128*>(x), static_cast<mplapackint>(incx), beta, y, static_cast<mplapackint>(incy));
+}
+
+inline void ger(blas_int m, blas_int n, uni20::float128 alpha, uni20::float128 const* x, blas_int incx,
+                uni20::float128 const* y, blas_int incy, uni20::float128* A, blas_int lda)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Rger, m, n, alpha, x, incx, y, incy, A, lda);
+  Rger(static_cast<mplapackint>(m), static_cast<mplapackint>(n), alpha, const_cast<uni20::float128*>(x),
+       static_cast<mplapackint>(incx), const_cast<uni20::float128*>(y), static_cast<mplapackint>(incy), A,
+       static_cast<mplapackint>(lda));
+}
+
+inline void syrk(char uplo, char trans, blas_int n, blas_int k, uni20::float128 alpha, uni20::float128 const* A,
+                 blas_int lda, uni20::float128 beta, uni20::float128* C, blas_int ldc)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Rsyrk, uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
+  char uplo_string[2]{};
+  char trans_string[2]{};
+  Rsyrk(mplapack_binary128_detail::char_string(uplo, uplo_string),
+        mplapack_binary128_detail::char_string(trans, trans_string), static_cast<mplapackint>(n),
+        static_cast<mplapackint>(k), alpha, const_cast<uni20::float128*>(A), static_cast<mplapackint>(lda), beta, C,
+        static_cast<mplapackint>(ldc));
+}
+
+inline void syr2k(char uplo, char trans, blas_int n, blas_int k, uni20::float128 alpha, uni20::float128 const* A,
+                  blas_int lda, uni20::float128 const* B, blas_int ldb, uni20::float128 beta, uni20::float128* C,
+                  blas_int ldc)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Rsyr2k, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+  char uplo_string[2]{};
+  char trans_string[2]{};
+  Rsyr2k(mplapack_binary128_detail::char_string(uplo, uplo_string),
+         mplapack_binary128_detail::char_string(trans, trans_string), static_cast<mplapackint>(n),
+         static_cast<mplapackint>(k), alpha, const_cast<uni20::float128*>(A), static_cast<mplapackint>(lda),
+         const_cast<uni20::float128*>(B), static_cast<mplapackint>(ldb), beta, C, static_cast<mplapackint>(ldc));
+}
+
+inline void gemm(char transa, char transb, blas_int m, blas_int n, blas_int k, uni20::complex<uni20::float128> alpha,
+                 uni20::complex<uni20::float128> const* A, blas_int lda, uni20::complex<uni20::float128> const* B,
+                 blas_int ldb, uni20::complex<uni20::float128> beta, uni20::complex<uni20::float128>* C, blas_int ldc)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Cgemm, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+  char transa_string[2]{};
+  char transb_string[2]{};
+  Cgemm(mplapack_binary128_detail::char_string(transa, transa_string),
+        mplapack_binary128_detail::char_string(transb, transb_string), static_cast<mplapackint>(m),
+        static_cast<mplapackint>(n), static_cast<mplapackint>(k), alpha,
+        const_cast<uni20::complex<uni20::float128>*>(A), static_cast<mplapackint>(lda),
+        const_cast<uni20::complex<uni20::float128>*>(B), static_cast<mplapackint>(ldb), beta, C,
+        static_cast<mplapackint>(ldc));
+}
+
+inline void gemv(char trans, blas_int m, blas_int n, uni20::complex<uni20::float128> alpha,
+                 uni20::complex<uni20::float128> const* A, blas_int lda, uni20::complex<uni20::float128> const* x,
+                 blas_int incx, uni20::complex<uni20::float128> beta, uni20::complex<uni20::float128>* y, blas_int incy)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Cgemv, trans, m, n, alpha, A, lda, x, incx, beta, y, incy);
+  char trans_string[2]{};
+  Cgemv(mplapack_binary128_detail::char_string(trans, trans_string), static_cast<mplapackint>(m),
+        static_cast<mplapackint>(n), alpha, const_cast<uni20::complex<uni20::float128>*>(A),
+        static_cast<mplapackint>(lda), const_cast<uni20::complex<uni20::float128>*>(x), static_cast<mplapackint>(incx),
+        beta, y, static_cast<mplapackint>(incy));
+}
+
+inline void geru(blas_int m, blas_int n, uni20::complex<uni20::float128> alpha,
+                 uni20::complex<uni20::float128> const* x, blas_int incx, uni20::complex<uni20::float128> const* y,
+                 blas_int incy, uni20::complex<uni20::float128>* A, blas_int lda)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Cgeru, m, n, alpha, x, incx, y, incy, A, lda);
+  Cgeru(static_cast<mplapackint>(m), static_cast<mplapackint>(n), alpha,
+        const_cast<uni20::complex<uni20::float128>*>(x), static_cast<mplapackint>(incx),
+        const_cast<uni20::complex<uni20::float128>*>(y), static_cast<mplapackint>(incy), A,
+        static_cast<mplapackint>(lda));
+}
+
+inline void gerc(blas_int m, blas_int n, uni20::complex<uni20::float128> alpha,
+                 uni20::complex<uni20::float128> const* x, blas_int incx, uni20::complex<uni20::float128> const* y,
+                 blas_int incy, uni20::complex<uni20::float128>* A, blas_int lda)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Cgerc, m, n, alpha, x, incx, y, incy, A, lda);
+  Cgerc(static_cast<mplapackint>(m), static_cast<mplapackint>(n), alpha,
+        const_cast<uni20::complex<uni20::float128>*>(x), static_cast<mplapackint>(incx),
+        const_cast<uni20::complex<uni20::float128>*>(y), static_cast<mplapackint>(incy), A,
+        static_cast<mplapackint>(lda));
+}
+
+inline void herk(char uplo, char trans, blas_int n, blas_int k, uni20::float128 alpha,
+                 uni20::complex<uni20::float128> const* A, blas_int lda, uni20::float128 beta,
+                 uni20::complex<uni20::float128>* C, blas_int ldc)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Cherk, uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
+  char uplo_string[2]{};
+  char trans_string[2]{};
+  Cherk(mplapack_binary128_detail::char_string(uplo, uplo_string),
+        mplapack_binary128_detail::char_string(trans, trans_string), static_cast<mplapackint>(n),
+        static_cast<mplapackint>(k), alpha, const_cast<uni20::complex<uni20::float128>*>(A),
+        static_cast<mplapackint>(lda), beta, C, static_cast<mplapackint>(ldc));
+}
+
+inline void her2k(char uplo, char trans, blas_int n, blas_int k, uni20::complex<uni20::float128> alpha,
+                  uni20::complex<uni20::float128> const* A, blas_int lda, uni20::complex<uni20::float128> const* B,
+                  blas_int ldb, uni20::float128 beta, uni20::complex<uni20::float128>* C, blas_int ldc)
+{
+  UNI20_EXTERNAL_API_CALL(BLAS, Cher2k, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+  char uplo_string[2]{};
+  char trans_string[2]{};
+  Cher2k(mplapack_binary128_detail::char_string(uplo, uplo_string),
+         mplapack_binary128_detail::char_string(trans, trans_string), static_cast<mplapackint>(n),
+         static_cast<mplapackint>(k), alpha, const_cast<uni20::complex<uni20::float128>*>(A),
+         static_cast<mplapackint>(lda), const_cast<uni20::complex<uni20::float128>*>(B), static_cast<mplapackint>(ldb),
+         beta, C, static_cast<mplapackint>(ldc));
+}
+
+} // namespace uni20::blas
+
+#endif

--- a/src/uni20/backend/lapack/lapack.hpp
+++ b/src/uni20/backend/lapack/lapack.hpp
@@ -17,6 +17,13 @@
 #include <stdexcept>
 #include <string>
 
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
+#include <uni20/backend/lapack/mplapack/band.hpp>
+#include <uni20/backend/lapack/mplapack/general.hpp>
+#include <uni20/backend/lapack/mplapack/norms.hpp>
+#include <uni20/backend/lapack/mplapack/tridiagonal.hpp>
+#endif
+
 namespace uni20::lapack
 {
 

--- a/src/uni20/backend/lapack/mplapack/band.hpp
+++ b/src/uni20/backend/lapack/mplapack/band.hpp
@@ -1,0 +1,221 @@
+#pragma once
+
+/**
+ * \file band.hpp
+ * \ingroup backend_lapack_mplapack
+ * \brief MPLAPACK binary128 wrappers for real band linear algebra.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/backend/lapack/common.hpp>
+#include <uni20/backend/lapack/mplapack/common.hpp>
+#include <uni20/config.hpp>
+#include <uni20/core/types.hpp>
+
+#if !(UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK)
+#error "uni20/backend/lapack/mplapack/band.hpp requires MPLAPACK float128 support"
+#endif
+
+// clang-format off
+#include <mplapack_config.h>
+#include <mplapack_binary128.h>
+// clang-format on
+
+namespace uni20::lapack::unchecked
+{
+
+[[nodiscard]] inline blas_int gbsv(blas_int n, blas_int kl, blas_int ku, blas_int nrhs, uni20::float128* ab,
+                                   blas_int ldab, blas_int* ipiv, uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgbsv, n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgbsv(static_cast<mplapackint>(n), static_cast<mplapackint>(kl), static_cast<mplapackint>(ku),
+        static_cast<mplapackint>(nrhs), ab, static_cast<mplapackint>(ldab), mplapack_ipiv.data(), b,
+        static_cast<mplapackint>(ldb), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gbtrf(blas_int m, blas_int n, blas_int kl, blas_int ku, uni20::float128* ab,
+                                    blas_int ldab, blas_int* ipiv)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgbtrf, m, n, kl, ku, ab, ldab, ipiv);
+  mplapackint mplapack_info = 0;
+  blas_int const pivot_count = std::min(m, n);
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::make_mplapack_int_work(pivot_count);
+  Rgbtrf(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(kl),
+         static_cast<mplapackint>(ku), ab, static_cast<mplapackint>(ldab), mplapack_ipiv.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, pivot_count);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gbtrs(char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs,
+                                    uni20::float128* ab, blas_int ldab, blas_int const* ipiv, uni20::float128* b,
+                                    blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgbtrs, trans, n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  Rgbtrs(&trans, static_cast<mplapackint>(n), static_cast<mplapackint>(kl), static_cast<mplapackint>(ku),
+         static_cast<mplapackint>(nrhs), ab, static_cast<mplapackint>(ldab), mplapack_ipiv.data(), b,
+         static_cast<mplapackint>(ldb), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gbcon(char norm, blas_int n, blas_int kl, blas_int ku, uni20::float128* ab, blas_int ldab,
+                                    blas_int const* ipiv, uni20::float128 anorm, uni20::float128& rcond,
+                                    uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgbcon, norm, n, kl, ku, ab, ldab, ipiv, anorm, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgbcon(&norm, static_cast<mplapackint>(n), static_cast<mplapackint>(kl), static_cast<mplapackint>(ku), ab,
+         static_cast<mplapackint>(ldab), mplapack_ipiv.data(), anorm, rcond, work, mplapack_iwork.data(),
+         mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gbrfs(char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs,
+                                    uni20::float128* ab, blas_int ldab, uni20::float128* afb, blas_int ldafb,
+                                    blas_int const* ipiv, uni20::float128* b, blas_int ldb, uni20::float128* x,
+                                    blas_int ldx, uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgbrfs, trans, n, kl, ku, nrhs, ab, ldab, afb, ldafb, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgbrfs(&trans, static_cast<mplapackint>(n), static_cast<mplapackint>(kl), static_cast<mplapackint>(ku),
+         static_cast<mplapackint>(nrhs), ab, static_cast<mplapackint>(ldab), afb, static_cast<mplapackint>(ldafb),
+         mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), x, static_cast<mplapackint>(ldx), forward_error,
+         backward_error, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gbsvx(char fact, char trans, blas_int n, blas_int kl, blas_int ku, blas_int nrhs,
+                                    uni20::float128* ab, blas_int ldab, uni20::float128* afb, blas_int ldafb,
+                                    blas_int* ipiv, char& equed, uni20::float128* row_scale,
+                                    uni20::float128* column_scale, uni20::float128* b, blas_int ldb, uni20::float128* x,
+                                    blas_int ldx, uni20::float128& rcond, uni20::float128* forward_error,
+                                    uni20::float128* backward_error, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgbsvx, fact, trans, n, kl, ku, nrhs, ab, ldab, afb, ldafb, ipiv, equed, row_scale,
+                          column_scale, b, ldb, x, ldx, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgbsvx(&fact, &trans, static_cast<mplapackint>(n), static_cast<mplapackint>(kl), static_cast<mplapackint>(ku),
+         static_cast<mplapackint>(nrhs), ab, static_cast<mplapackint>(ldab), afb, static_cast<mplapackint>(ldafb),
+         mplapack_ipiv.data(), &equed, row_scale, column_scale, b, static_cast<mplapackint>(ldb), x,
+         static_cast<mplapackint>(ldx), rcond, forward_error, backward_error, work, mplapack_iwork.data(),
+         mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, n);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gbequ(bool power_of_two, blas_int m, blas_int n, blas_int kl, blas_int ku,
+                                    uni20::float128* ab, blas_int ldab, uni20::float128* row_scale,
+                                    uni20::float128* column_scale, uni20::float128& row_condition,
+                                    uni20::float128& column_condition, uni20::float128& max_abs)
+{
+  mplapackint mplapack_info = 0;
+  if (power_of_two)
+  {
+    UNI20_EXTERNAL_API_CALL(LAPACK, Rgbequb, m, n, kl, ku, ab, ldab, row_scale, column_scale);
+    Rgbequb(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(kl),
+            static_cast<mplapackint>(ku), ab, static_cast<mplapackint>(ldab), row_scale, column_scale, row_condition,
+            column_condition, max_abs, mplapack_info);
+  }
+  else
+  {
+    UNI20_EXTERNAL_API_CALL(LAPACK, Rgbequ, m, n, kl, ku, ab, ldab, row_scale, column_scale);
+    Rgbequ(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(kl),
+           static_cast<mplapackint>(ku), ab, static_cast<mplapackint>(ldab), row_scale, column_scale, row_condition,
+           column_condition, max_abs, mplapack_info);
+  }
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pbsv(char uplo, blas_int n, blas_int kd, blas_int nrhs, uni20::float128* ab,
+                                   blas_int ldab, uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpbsv, uplo, n, kd, nrhs, ab, ldab, b, ldb);
+  mplapackint mplapack_info = 0;
+  Rpbsv(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(kd), static_cast<mplapackint>(nrhs), ab,
+        static_cast<mplapackint>(ldab), b, static_cast<mplapackint>(ldb), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pbtrf(char uplo, blas_int n, blas_int kd, uni20::float128* ab, blas_int ldab)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpbtrf, uplo, n, kd, ab, ldab);
+  mplapackint mplapack_info = 0;
+  Rpbtrf(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(kd), ab, static_cast<mplapackint>(ldab),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pbtrs(char uplo, blas_int n, blas_int kd, blas_int nrhs, uni20::float128* ab,
+                                    blas_int ldab, uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpbtrs, uplo, n, kd, nrhs, ab, ldab, b, ldb);
+  mplapackint mplapack_info = 0;
+  Rpbtrs(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(kd), static_cast<mplapackint>(nrhs), ab,
+         static_cast<mplapackint>(ldab), b, static_cast<mplapackint>(ldb), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pbcon(char uplo, blas_int n, blas_int kd, uni20::float128* ab, blas_int ldab,
+                                    uni20::float128 anorm, uni20::float128& rcond, uni20::float128* work,
+                                    blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpbcon, uplo, n, kd, ab, ldab, anorm, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rpbcon(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(kd), ab, static_cast<mplapackint>(ldab), anorm,
+         rcond, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pbrfs(char uplo, blas_int n, blas_int kd, blas_int nrhs, uni20::float128* ab,
+                                    blas_int ldab, uni20::float128* afb, blas_int ldafb, uni20::float128* b,
+                                    blas_int ldb, uni20::float128* x, blas_int ldx, uni20::float128* forward_error,
+                                    uni20::float128* backward_error, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpbrfs, uplo, n, kd, nrhs, ab, ldab, afb, ldafb, b, ldb, x, ldx, forward_error,
+                          backward_error, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rpbrfs(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(kd), static_cast<mplapackint>(nrhs), ab,
+         static_cast<mplapackint>(ldab), afb, static_cast<mplapackint>(ldafb), b, static_cast<mplapackint>(ldb), x,
+         static_cast<mplapackint>(ldx), forward_error, backward_error, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pbsvx(char fact, char uplo, blas_int n, blas_int kd, blas_int nrhs, uni20::float128* ab,
+                                    blas_int ldab, uni20::float128* afb, blas_int ldafb, char& equed,
+                                    uni20::float128* scale, uni20::float128* b, blas_int ldb, uni20::float128* x,
+                                    blas_int ldx, uni20::float128& rcond, uni20::float128* forward_error,
+                                    uni20::float128* backward_error, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpbsvx, fact, uplo, n, kd, nrhs, ab, ldab, afb, ldafb, equed, scale, b, ldb, x, ldx,
+                          work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rpbsvx(&fact, &uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(kd), static_cast<mplapackint>(nrhs), ab,
+         static_cast<mplapackint>(ldab), afb, static_cast<mplapackint>(ldafb), &equed, scale, b,
+         static_cast<mplapackint>(ldb), x, static_cast<mplapackint>(ldx), rcond, forward_error, backward_error, work,
+         mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+} // namespace uni20::lapack::unchecked

--- a/src/uni20/backend/lapack/mplapack/common.hpp
+++ b/src/uni20/backend/lapack/mplapack/common.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+/**
+ * \file common.hpp
+ * \ingroup backend_lapack_mplapack
+ * \brief Shared helpers for MPLAPACK LAPACK wrappers.
+ */
+
+#include <uni20/config.hpp>
+
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
+// clang-format off
+#include <mplapack_config.h>
+#include <mplapack_binary128.h>
+// clang-format on
+#endif
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+namespace uni20::lapack::mplapack::detail
+{
+
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
+
+inline std::size_t lapack_int_work_size(blas_int count)
+{
+  return static_cast<std::size_t>(std::max<blas_int>(1, count));
+}
+
+inline std::vector<mplapackint> make_mplapack_int_work(blas_int count)
+{
+  return std::vector<mplapackint>(lapack_int_work_size(count));
+}
+
+inline std::vector<mplapackint> to_mplapack_ints(blas_int const* values, blas_int count)
+{
+  std::vector<mplapackint> result = make_mplapack_int_work(count);
+  for (blas_int i = 0; i < count; ++i)
+  {
+    result[static_cast<std::size_t>(i)] = static_cast<mplapackint>(values[i]);
+  }
+  return result;
+}
+
+inline void copy_from_mplapack_ints(std::vector<mplapackint> const& source, blas_int* target, blas_int count)
+{
+  for (blas_int i = 0; i < count; ++i)
+  {
+    target[i] = static_cast<blas_int>(source[static_cast<std::size_t>(i)]);
+  }
+}
+
+inline blas_int checked_blas_int(std::size_t value)
+{
+  auto const converted = static_cast<blas_int>(value);
+  if (static_cast<std::size_t>(converted) != value)
+  {
+    throw std::overflow_error("LAPACK workspace dimension does not fit BLAS integer type");
+  }
+  return converted;
+}
+
+inline blas_int gelsd_iwork_size(blas_int m, blas_int n)
+{
+  blas_int const minmn = std::min(m, n);
+  if (minmn <= 0)
+  {
+    return 1;
+  }
+
+  // LAPACK's bound uses SMLSIZ from ILAENV. Using divisor 2 overestimates the
+  // subdivision depth, avoiding a runtime dependency on ILAENV in this wrapper.
+  std::size_t levels = 0;
+  for (std::size_t size = static_cast<std::size_t>(minmn) / 2; size > 0; size /= 2)
+  {
+    ++levels;
+  }
+  std::size_t const minmn_size = static_cast<std::size_t>(minmn);
+  std::size_t const required = 3 * minmn_size * levels + 11 * minmn_size;
+  return checked_blas_int(std::max<std::size_t>(1, required));
+}
+
+#endif
+
+} // namespace uni20::lapack::mplapack::detail

--- a/src/uni20/backend/lapack/mplapack/general.hpp
+++ b/src/uni20/backend/lapack/mplapack/general.hpp
@@ -1,0 +1,1485 @@
+#pragma once
+
+/**
+ * \file general.hpp
+ * \ingroup backend_lapack_mplapack
+ * \brief MPLAPACK binary128 wrappers for real dense general linear systems.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/backend/lapack/common.hpp>
+#include <uni20/backend/lapack/mplapack/common.hpp>
+#include <uni20/config.hpp>
+#include <uni20/core/types.hpp>
+
+#include <memory>
+
+#if !(UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK)
+#error "uni20/backend/lapack/mplapack/general.hpp requires MPLAPACK float128 support"
+#endif
+
+// clang-format off
+#include <mplapack_config.h>
+#include <mplapack_binary128.h>
+// clang-format on
+
+namespace uni20::lapack::unchecked
+{
+
+[[nodiscard]] inline blas_int gesv(blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda, blas_int* ipiv,
+                                   uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgesv, n, nrhs, a, lda, ipiv, b, ldb);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgesv(static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda),
+        mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gesvx(char fact, char trans, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* af, blas_int ldaf, blas_int* ipiv, char& equed,
+                                    uni20::float128* row_scale, uni20::float128* column_scale, uni20::float128* b,
+                                    blas_int ldb, uni20::float128* x, blas_int ldx, uni20::float128& rcond,
+                                    uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgesvx, fact, trans, n, nrhs, a, lda, af, ldaf, ipiv, equed, row_scale, column_scale,
+                          b, ldb, x, ldx, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgesvx(&fact, &trans, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda),
+         af, static_cast<mplapackint>(ldaf), mplapack_ipiv.data(), &equed, row_scale, column_scale, b,
+         static_cast<mplapackint>(ldb), x, static_cast<mplapackint>(ldx), rcond, forward_error, backward_error, work,
+         mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, n);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int geequ(blas_int m, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128* row_scale, uni20::float128* column_scale,
+                                    uni20::float128& row_condition, uni20::float128& column_condition,
+                                    uni20::float128& max_abs)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgeequ, m, n, a, lda, row_scale, column_scale);
+  mplapackint mplapack_info = 0;
+  Rgeequ(static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), row_scale,
+         column_scale, row_condition, column_condition, max_abs, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int getrf(blas_int m, blas_int n, uni20::float128* a, blas_int lda, blas_int* ipiv)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgetrf, m, n, a, lda, ipiv);
+  mplapackint mplapack_info = 0;
+  blas_int const pivot_count = std::min(m, n);
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::make_mplapack_int_work(pivot_count);
+  Rgetrf(static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda),
+         mplapack_ipiv.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, pivot_count);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int getrs(char trans, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    blas_int const* ipiv, uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgetrs, trans, n, nrhs, a, lda, ipiv, b, ldb);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  Rgetrs(&trans, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda),
+         mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gerfs(char trans, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* factors, blas_int factor_lda, blas_int const* ipiv,
+                                    uni20::float128* b, blas_int ldb, uni20::float128* x, blas_int ldx,
+                                    uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgerfs, trans, n, nrhs, a, lda, factors, factor_lda, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgerfs(&trans, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda), factors,
+         static_cast<mplapackint>(factor_lda), mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), x,
+         static_cast<mplapackint>(ldx), forward_error, backward_error, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int getri(blas_int n, uni20::float128* a, blas_int lda, blas_int* ipiv, uni20::float128* work,
+                                    blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgetri, n, a, lda, ipiv, work, lwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  Rgetri(static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_ipiv.data(), work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gecon(char norm, blas_int n, uni20::float128 const* a, blas_int lda,
+                                    uni20::float128 anorm, uni20::float128& rcond, uni20::float128* work,
+                                    blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgecon, norm, n, a, lda, anorm, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgecon(&norm, static_cast<mplapackint>(n), const_cast<uni20::float128*>(a), static_cast<mplapackint>(lda), anorm,
+         rcond, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gels(char trans, blas_int m, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                   uni20::float128* b, blas_int ldb, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgels, trans, m, n, nrhs, a, lda, b, ldb, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgels(&trans, static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a,
+        static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), work, static_cast<mplapackint>(lwork),
+        mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gelss(blas_int m, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* b, blas_int ldb, uni20::float128* s, uni20::float128 rcond,
+                                    blas_int& rank, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgelss, m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork);
+  mplapackint mplapack_rank = 0;
+  mplapackint mplapack_info = 0;
+  Rgelss(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a,
+         static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), s, rcond, mplapack_rank, work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  rank = static_cast<blas_int>(mplapack_rank);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gelsd(blas_int m, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* b, blas_int ldb, uni20::float128* s, uni20::float128 rcond,
+                                    blas_int& rank, uni20::float128* work, blas_int lwork, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgelsd, m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, iwork);
+  mplapackint mplapack_rank = 0;
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = uni20::lapack::mplapack::detail::gelsd_iwork_size(m, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(iwork_size);
+  Rgelsd(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a,
+         static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), s, rcond, mplapack_rank, work,
+         static_cast<mplapackint>(lwork), mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  rank = static_cast<blas_int>(mplapack_rank);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gelsy(blas_int m, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* b, blas_int ldb, blas_int* jpvt, uni20::float128 rcond,
+                                    blas_int& rank, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgelsy, m, n, nrhs, a, lda, b, ldb, jpvt, rcond, rank, work, lwork);
+  mplapackint mplapack_rank = 0;
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_jpvt = uni20::lapack::mplapack::detail::to_mplapack_ints(jpvt, n);
+  Rgelsy(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a,
+         static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), mplapack_jpvt.data(), rcond, mplapack_rank,
+         work, static_cast<mplapackint>(lwork), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_jpvt, jpvt, n);
+  rank = static_cast<blas_int>(mplapack_rank);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int geqrf(blas_int m, blas_int n, uni20::float128* a, blas_int lda, uni20::float128* tau,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgeqrf, m, n, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgeqrf(static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), tau, work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gelqf(blas_int m, blas_int n, uni20::float128* a, blas_int lda, uni20::float128* tau,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgelqf, m, n, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgelqf(static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), tau, work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int geqlf(blas_int m, blas_int n, uni20::float128* a, blas_int lda, uni20::float128* tau,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgeqlf, m, n, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgeqlf(static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), tau, work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gerqf(blas_int m, blas_int n, uni20::float128* a, blas_int lda, uni20::float128* tau,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgerqf, m, n, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgerqf(static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), tau, work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int orgqr(blas_int m, blas_int n, blas_int k, uni20::float128* a, blas_int lda,
+                                    uni20::float128* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rorgqr, m, n, k, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rorgqr(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int orglq(blas_int m, blas_int n, blas_int k, uni20::float128* a, blas_int lda,
+                                    uni20::float128* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rorglq, m, n, k, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rorglq(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int orgql(blas_int m, blas_int n, blas_int k, uni20::float128* a, blas_int lda,
+                                    uni20::float128* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rorgql, m, n, k, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rorgql(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int orgrq(blas_int m, blas_int n, blas_int k, uni20::float128* a, blas_int lda,
+                                    uni20::float128* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rorgrq, m, n, k, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rorgrq(static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ormqr(char side, char trans, blas_int m, blas_int n, blas_int k, uni20::float128* a,
+                                    blas_int lda, uni20::float128* tau, uni20::float128* c, blas_int ldc,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rormqr, side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rormqr(&side, &trans, static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, c, static_cast<mplapackint>(ldc), work, static_cast<mplapackint>(lwork),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ormlq(char side, char trans, blas_int m, blas_int n, blas_int k, uni20::float128* a,
+                                    blas_int lda, uni20::float128* tau, uni20::float128* c, blas_int ldc,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rormlq, side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rormlq(&side, &trans, static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, c, static_cast<mplapackint>(ldc), work, static_cast<mplapackint>(lwork),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ormql(char side, char trans, blas_int m, blas_int n, blas_int k, uni20::float128* a,
+                                    blas_int lda, uni20::float128* tau, uni20::float128* c, blas_int ldc,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rormql, side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rormql(&side, &trans, static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, c, static_cast<mplapackint>(ldc), work, static_cast<mplapackint>(lwork),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ormrq(char side, char trans, blas_int m, blas_int n, blas_int k, uni20::float128* a,
+                                    blas_int lda, uni20::float128* tau, uni20::float128* c, blas_int ldc,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rormrq, side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rormrq(&side, &trans, static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, c, static_cast<mplapackint>(ldc), work, static_cast<mplapackint>(lwork),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gebrd(blas_int m, blas_int n, uni20::float128* a, blas_int lda, uni20::float128* d,
+                                    uni20::float128* e, uni20::float128* tauq, uni20::float128* taup,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgebrd, m, n, a, lda, d, e, tauq, taup, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgebrd(static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), d, e, tauq, taup,
+         work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gehrd(blas_int n, blas_int first, blas_int last, uni20::float128* a, blas_int lda,
+                                    uni20::float128* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgehrd, n, first, last, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgehrd(static_cast<mplapackint>(n), static_cast<mplapackint>(first), static_cast<mplapackint>(last), a,
+         static_cast<mplapackint>(lda), tau, work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int geqp3(blas_int m, blas_int n, uni20::float128* a, blas_int lda, blas_int* jpvt,
+                                    uni20::float128* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgeqp3, m, n, a, lda, jpvt, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_jpvt = uni20::lapack::mplapack::detail::to_mplapack_ints(jpvt, n);
+  Rgeqp3(static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda),
+         mplapack_jpvt.data(), tau, work, static_cast<mplapackint>(lwork), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_jpvt, jpvt, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sytrd(char uplo, blas_int n, uni20::float128* a, blas_int lda, uni20::float128* d,
+                                    uni20::float128* e, uni20::float128* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsytrd, uplo, n, a, lda, d, e, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rsytrd(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), d, e, tau, work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int syev(char jobz, char uplo, blas_int n, uni20::float128* a, blas_int lda,
+                                   uni20::float128* w, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsyev, jobz, uplo, n, a, lda, w, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rsyev(&jobz, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), w, work,
+        static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int syevd(char jobz, char uplo, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128* w, uni20::float128* work, blas_int lwork, blas_int* iwork,
+                                    blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsyevd, jobz, uplo, n, a, lda, w, work, lwork, iwork, liwork);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rsyevd(&jobz, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), w, work,
+         static_cast<mplapackint>(lwork), mplapack_iwork.data(), static_cast<mplapackint>(liwork), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int syevr(char jobz, char range, char uplo, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128 vl, uni20::float128 vu, blas_int il, blas_int iu,
+                                    uni20::float128 abstol, blas_int& selected_count, uni20::float128* w,
+                                    uni20::float128* z, blas_int ldz, blas_int* isuppz, uni20::float128* work,
+                                    blas_int lwork, blas_int* iwork, blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsyevr, jobz, range, uplo, n, a, lda, vl, vu, il, iu, abstol, selected_count, w, z,
+                          ldz, isuppz, work, lwork, iwork, liwork);
+  mplapackint mplapack_selected_count = static_cast<mplapackint>(selected_count);
+  mplapackint mplapack_info = 0;
+  blas_int const support_size = 2 * std::max<blas_int>(1, n);
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  std::vector<mplapackint> mplapack_isuppz = uni20::lapack::mplapack::detail::to_mplapack_ints(isuppz, support_size);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rsyevr(&jobz, &range, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), vl, vu,
+         static_cast<mplapackint>(il), static_cast<mplapackint>(iu), abstol, mplapack_selected_count, w, z,
+         static_cast<mplapackint>(ldz), mplapack_isuppz.data(), work, static_cast<mplapackint>(lwork),
+         mplapack_iwork.data(), static_cast<mplapackint>(liwork), mplapack_info);
+  selected_count = static_cast<blas_int>(mplapack_selected_count);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_isuppz, isuppz, support_size);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sygv(blas_int itype, char jobz, char uplo, blas_int n, uni20::float128* a, blas_int lda,
+                                   uni20::float128* b, blas_int ldb, uni20::float128* w, uni20::float128* work,
+                                   blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsygv, itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rsygv(static_cast<mplapackint>(itype), &jobz, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), b,
+        static_cast<mplapackint>(ldb), w, work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sygvd(blas_int itype, char jobz, char uplo, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128* b, blas_int ldb, uni20::float128* w, uni20::float128* work,
+                                    blas_int lwork, blas_int* iwork, blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsygvd, itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, iwork, liwork);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rsygvd(static_cast<mplapackint>(itype), &jobz, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda),
+         b, static_cast<mplapackint>(ldb), w, work, static_cast<mplapackint>(lwork), mplapack_iwork.data(),
+         static_cast<mplapackint>(liwork), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sygvx(blas_int itype, char jobz, char range, char uplo, blas_int n, uni20::float128* a,
+                                    blas_int lda, uni20::float128* b, blas_int ldb, uni20::float128 vl,
+                                    uni20::float128 vu, blas_int il, blas_int iu, uni20::float128 abstol,
+                                    blas_int& selected_count, uni20::float128* w, uni20::float128* z, blas_int ldz,
+                                    uni20::float128* work, blas_int lwork, blas_int* iwork, blas_int* ifail)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsygvx, itype, jobz, range, uplo, n, a, lda, b, ldb, vl, vu, il, iu, abstol,
+                          selected_count, w, z, ldz, work, lwork, iwork, ifail);
+  mplapackint mplapack_selected_count = static_cast<mplapackint>(selected_count);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = 5 * std::max<blas_int>(1, n);
+  blas_int const fail_size = std::max<blas_int>(1, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  std::vector<mplapackint> mplapack_ifail = uni20::lapack::mplapack::detail::to_mplapack_ints(ifail, fail_size);
+  Rsygvx(static_cast<mplapackint>(itype), &jobz, &range, &uplo, static_cast<mplapackint>(n), a,
+         static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), vl, vu, static_cast<mplapackint>(il),
+         static_cast<mplapackint>(iu), abstol, mplapack_selected_count, w, z, static_cast<mplapackint>(ldz), work,
+         static_cast<mplapackint>(lwork), mplapack_iwork.data(), mplapack_ifail.data(), mplapack_info);
+  selected_count = static_cast<blas_int>(mplapack_selected_count);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ifail, ifail, fail_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int heev(char jobz, char uplo, blas_int n, uni20::complex<uni20::float128>* a, blas_int lda,
+                                   uni20::float128* w, uni20::complex<uni20::float128>* work, blas_int lwork,
+                                   uni20::float128* rwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Cheev, jobz, uplo, n, a, lda, w, work, lwork, rwork);
+  mplapackint mplapack_info = 0;
+  Cheev(&jobz, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), w, work,
+        static_cast<mplapackint>(lwork), rwork, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int heevd(char jobz, char uplo, blas_int n, uni20::complex<uni20::float128>* a, blas_int lda,
+                                    uni20::float128* w, uni20::complex<uni20::float128>* work, blas_int lwork,
+                                    uni20::float128* rwork, blas_int lrwork, blas_int* iwork, blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Cheevd, jobz, uplo, n, a, lda, w, work, lwork, rwork, lrwork, iwork, liwork);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Cheevd(&jobz, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), w, work,
+         static_cast<mplapackint>(lwork), rwork, static_cast<mplapackint>(lrwork), mplapack_iwork.data(),
+         static_cast<mplapackint>(liwork), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int heevr(char jobz, char range, char uplo, blas_int n, uni20::complex<uni20::float128>* a,
+                                    blas_int lda, uni20::float128 vl, uni20::float128 vu, blas_int il, blas_int iu,
+                                    uni20::float128 abstol, blas_int& selected_count, uni20::float128* w,
+                                    uni20::complex<uni20::float128>* z, blas_int ldz, blas_int* isuppz,
+                                    uni20::complex<uni20::float128>* work, blas_int lwork, uni20::float128* rwork,
+                                    blas_int lrwork, blas_int* iwork, blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Cheevr, jobz, range, uplo, n, a, lda, vl, vu, il, iu, abstol, selected_count, w, z,
+                          ldz, isuppz, work, lwork, rwork, lrwork, iwork, liwork);
+  mplapackint mplapack_selected_count = static_cast<mplapackint>(selected_count);
+  mplapackint mplapack_info = 0;
+  blas_int const support_size = 2 * std::max<blas_int>(1, n);
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  std::vector<mplapackint> mplapack_isuppz = uni20::lapack::mplapack::detail::to_mplapack_ints(isuppz, support_size);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Cheevr(&jobz, &range, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), vl, vu,
+         static_cast<mplapackint>(il), static_cast<mplapackint>(iu), abstol, mplapack_selected_count, w, z,
+         static_cast<mplapackint>(ldz), mplapack_isuppz.data(), work, static_cast<mplapackint>(lwork), rwork,
+         static_cast<mplapackint>(lrwork), mplapack_iwork.data(), static_cast<mplapackint>(liwork), mplapack_info);
+  selected_count = static_cast<blas_int>(mplapack_selected_count);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_isuppz, isuppz, support_size);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int hegv(blas_int itype, char jobz, char uplo, blas_int n, uni20::complex<uni20::float128>* a,
+                                   blas_int lda, uni20::complex<uni20::float128>* b, blas_int ldb, uni20::float128* w,
+                                   uni20::complex<uni20::float128>* work, blas_int lwork, uni20::float128* rwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Chegv, itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, rwork);
+  mplapackint mplapack_info = 0;
+  Chegv(static_cast<mplapackint>(itype), &jobz, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), b,
+        static_cast<mplapackint>(ldb), w, work, static_cast<mplapackint>(lwork), rwork, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int hegvd(blas_int itype, char jobz, char uplo, blas_int n,
+                                    uni20::complex<uni20::float128>* a, blas_int lda,
+                                    uni20::complex<uni20::float128>* b, blas_int ldb, uni20::float128* w,
+                                    uni20::complex<uni20::float128>* work, blas_int lwork, uni20::float128* rwork,
+                                    blas_int lrwork, blas_int* iwork, blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Chegvd, itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, rwork, lrwork, iwork,
+                          liwork);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Chegvd(static_cast<mplapackint>(itype), &jobz, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda),
+         b, static_cast<mplapackint>(ldb), w, work, static_cast<mplapackint>(lwork), rwork,
+         static_cast<mplapackint>(lrwork), mplapack_iwork.data(), static_cast<mplapackint>(liwork), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int hegvx(blas_int itype, char jobz, char range, char uplo, blas_int n,
+                                    uni20::complex<uni20::float128>* a, blas_int lda,
+                                    uni20::complex<uni20::float128>* b, blas_int ldb, uni20::float128 vl,
+                                    uni20::float128 vu, blas_int il, blas_int iu, uni20::float128 abstol,
+                                    blas_int& selected_count, uni20::float128* w, uni20::complex<uni20::float128>* z,
+                                    blas_int ldz, uni20::complex<uni20::float128>* work, blas_int lwork,
+                                    uni20::float128* rwork, blas_int* iwork, blas_int* ifail)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Chegvx, itype, jobz, range, uplo, n, a, lda, b, ldb, vl, vu, il, iu, abstol,
+                          selected_count, w, z, ldz, work, lwork, rwork, iwork, ifail);
+  mplapackint mplapack_selected_count = static_cast<mplapackint>(selected_count);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = 5 * std::max<blas_int>(1, n);
+  blas_int const fail_size = std::max<blas_int>(1, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  std::vector<mplapackint> mplapack_ifail = uni20::lapack::mplapack::detail::to_mplapack_ints(ifail, fail_size);
+  Chegvx(static_cast<mplapackint>(itype), &jobz, &range, &uplo, static_cast<mplapackint>(n), a,
+         static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), vl, vu, static_cast<mplapackint>(il),
+         static_cast<mplapackint>(iu), abstol, mplapack_selected_count, w, z, static_cast<mplapackint>(ldz), work,
+         static_cast<mplapackint>(lwork), rwork, mplapack_iwork.data(), mplapack_ifail.data(), mplapack_info);
+  selected_count = static_cast<blas_int>(mplapack_selected_count);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ifail, ifail, fail_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int geev(char jobvl, char jobvr, blas_int n, uni20::float128* a, blas_int lda,
+                                   uni20::float128* wr, uni20::float128* wi, uni20::float128* vl, blas_int ldvl,
+                                   uni20::float128* vr, blas_int ldvr, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgeev, jobvl, jobvr, n, a, lda, wr, wi, vl, ldvl, vr, ldvr, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgeev(&jobvl, &jobvr, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), wr, wi, vl,
+        static_cast<mplapackint>(ldvl), vr, static_cast<mplapackint>(ldvr), work, static_cast<mplapackint>(lwork),
+        mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int geevx(char balanc, char jobvl, char jobvr, char sense, blas_int n, uni20::float128* a,
+                                    blas_int lda, uni20::float128* wr, uni20::float128* wi, uni20::float128* vl,
+                                    blas_int ldvl, uni20::float128* vr, blas_int ldvr, blas_int& ilo, blas_int& ihi,
+                                    uni20::float128* scale, uni20::float128& abnrm, uni20::float128* rconde,
+                                    uni20::float128* rcondv, uni20::float128* work, blas_int lwork, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgeevx, balanc, jobvl, jobvr, sense, n, a, lda, wr, wi, vl, ldvl, vr, ldvr, ilo, ihi,
+                          scale, abnrm, rconde, rcondv, work, lwork, iwork);
+  mplapackint mplapack_ilo = static_cast<mplapackint>(ilo);
+  mplapackint mplapack_ihi = static_cast<mplapackint>(ihi);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = std::max<blas_int>(1, 2 * n - 2);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rgeevx(&balanc, &jobvl, &jobvr, &sense, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), wr, wi, vl,
+         static_cast<mplapackint>(ldvl), vr, static_cast<mplapackint>(ldvr), mplapack_ilo, mplapack_ihi, scale, abnrm,
+         rconde, rcondv, work, static_cast<mplapackint>(lwork), mplapack_iwork.data(), mplapack_info);
+  ilo = static_cast<blas_int>(mplapack_ilo);
+  ihi = static_cast<blas_int>(mplapack_ihi);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gebal(char job, blas_int n, uni20::float128* a, blas_int lda, blas_int& first,
+                                    blas_int& last, uni20::float128* scale)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgebal, job, n, a, lda, first, last, scale);
+  mplapackint mplapack_first = static_cast<mplapackint>(first);
+  mplapackint mplapack_last = static_cast<mplapackint>(last);
+  mplapackint mplapack_info = 0;
+  Rgebal(&job, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_first, mplapack_last, scale,
+         mplapack_info);
+  first = static_cast<blas_int>(mplapack_first);
+  last = static_cast<blas_int>(mplapack_last);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gebak(char job, char side, blas_int n, blas_int first, blas_int last,
+                                    uni20::float128* scale, blas_int vector_count, uni20::float128* vectors,
+                                    blas_int leading_dimension)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgebak, job, side, n, first, last, scale, vector_count, vectors, leading_dimension);
+  mplapackint mplapack_info = 0;
+  Rgebak(&job, &side, static_cast<mplapackint>(n), static_cast<mplapackint>(first), static_cast<mplapackint>(last),
+         scale, static_cast<mplapackint>(vector_count), vectors, static_cast<mplapackint>(leading_dimension),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int geev(char jobvl, char jobvr, blas_int n, uni20::complex<uni20::float128>* a, blas_int lda,
+                                   uni20::complex<uni20::float128>* w, uni20::complex<uni20::float128>* vl,
+                                   blas_int ldvl, uni20::complex<uni20::float128>* vr, blas_int ldvr,
+                                   uni20::complex<uni20::float128>* work, blas_int lwork, uni20::float128* rwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Cgeev, jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork);
+  mplapackint mplapack_info = 0;
+  Cgeev(&jobvl, &jobvr, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), w, vl,
+        static_cast<mplapackint>(ldvl), vr, static_cast<mplapackint>(ldvr), work, static_cast<mplapackint>(lwork),
+        rwork, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gees(char jobvs, char sort, blas_int n, uni20::float128* a, blas_int lda,
+                                   blas_int& selected_dimension, uni20::float128* wr, uni20::float128* wi,
+                                   uni20::float128* vs, blas_int ldvs, uni20::float128* work, blas_int lwork,
+                                   blas_int* bwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgees, jobvs, sort, n, a, lda, selected_dimension, wr, wi, vs, ldvs, work, lwork,
+                          bwork);
+  mplapackint mplapack_selected_dimension = static_cast<mplapackint>(selected_dimension);
+  mplapackint mplapack_info = 0;
+  blas_int const bwork_size = std::max<blas_int>(1, n);
+  std::unique_ptr<bool[]> mplapack_bwork;
+  if (bwork != nullptr)
+  {
+    mplapack_bwork = std::make_unique<bool[]>(static_cast<std::size_t>(bwork_size));
+    for (blas_int i = 0; i < bwork_size; ++i)
+    {
+      mplapack_bwork[static_cast<std::size_t>(i)] = bwork[i] != 0;
+    }
+  }
+  Rgees(&jobvs, &sort, nullptr, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda),
+        mplapack_selected_dimension, wr, wi, vs, static_cast<mplapackint>(ldvs), work, static_cast<mplapackint>(lwork),
+        mplapack_bwork.get(), mplapack_info);
+  selected_dimension = static_cast<blas_int>(mplapack_selected_dimension);
+  if (bwork != nullptr)
+  {
+    for (blas_int i = 0; i < bwork_size; ++i)
+    {
+      bwork[i] = mplapack_bwork[static_cast<std::size_t>(i)] ? 1 : 0;
+    }
+  }
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gees(char jobvs, char sort, blas_int n, uni20::complex<uni20::float128>* a, blas_int lda,
+                                   blas_int& selected_dimension, uni20::complex<uni20::float128>* w,
+                                   uni20::complex<uni20::float128>* vs, blas_int ldvs,
+                                   uni20::complex<uni20::float128>* work, blas_int lwork, uni20::float128* rwork,
+                                   blas_int* bwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Cgees, jobvs, sort, n, a, lda, selected_dimension, w, vs, ldvs, work, lwork, rwork,
+                          bwork);
+  mplapackint mplapack_selected_dimension = static_cast<mplapackint>(selected_dimension);
+  mplapackint mplapack_info = 0;
+  blas_int const bwork_size = std::max<blas_int>(1, n);
+  std::unique_ptr<bool[]> mplapack_bwork;
+  if (bwork != nullptr)
+  {
+    mplapack_bwork = std::make_unique<bool[]>(static_cast<std::size_t>(bwork_size));
+    for (blas_int i = 0; i < bwork_size; ++i)
+    {
+      mplapack_bwork[static_cast<std::size_t>(i)] = bwork[i] != 0;
+    }
+  }
+  Cgees(&jobvs, &sort, nullptr, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda),
+        mplapack_selected_dimension, w, vs, static_cast<mplapackint>(ldvs), work, static_cast<mplapackint>(lwork),
+        rwork, mplapack_bwork.get(), mplapack_info);
+  selected_dimension = static_cast<blas_int>(mplapack_selected_dimension);
+  if (bwork != nullptr)
+  {
+    for (blas_int i = 0; i < bwork_size; ++i)
+    {
+      bwork[i] = mplapack_bwork[static_cast<std::size_t>(i)] ? 1 : 0;
+    }
+  }
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int hseqr(char job, char compz, blas_int n, blas_int first, blas_int last, uni20::float128* h,
+                                    blas_int ldh, uni20::float128* wr, uni20::float128* wi, uni20::float128* z,
+                                    blas_int ldz, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rhseqr, job, compz, n, first, last, h, ldh, wr, wi, z, ldz, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rhseqr(&job, &compz, static_cast<mplapackint>(n), static_cast<mplapackint>(first), static_cast<mplapackint>(last), h,
+         static_cast<mplapackint>(ldh), wr, wi, z, static_cast<mplapackint>(ldz), work, static_cast<mplapackint>(lwork),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trexc(char compq, blas_int n, uni20::float128* t, blas_int ldt, uni20::float128* q,
+                                    blas_int ldq, blas_int& first, blas_int& last, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrexc, compq, n, t, ldt, q, ldq, first, last, work);
+  mplapackint mplapack_first = static_cast<mplapackint>(first);
+  mplapackint mplapack_last = static_cast<mplapackint>(last);
+  mplapackint mplapack_info = 0;
+  Rtrexc(&compq, static_cast<mplapackint>(n), t, static_cast<mplapackint>(ldt), q, static_cast<mplapackint>(ldq),
+         mplapack_first, mplapack_last, work, mplapack_info);
+  first = static_cast<blas_int>(mplapack_first);
+  last = static_cast<blas_int>(mplapack_last);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trexc(char compq, blas_int n, uni20::complex<uni20::float128>* t, blas_int ldt,
+                                    uni20::complex<uni20::float128>* q, blas_int ldq, blas_int& first, blas_int& last)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Ctrexc, compq, n, t, ldt, q, ldq, first, last);
+  mplapackint mplapack_first = static_cast<mplapackint>(first);
+  mplapackint mplapack_last = static_cast<mplapackint>(last);
+  mplapackint mplapack_info = 0;
+  Ctrexc(&compq, static_cast<mplapackint>(n), t, static_cast<mplapackint>(ldt), q, static_cast<mplapackint>(ldq),
+         mplapack_first, mplapack_last, mplapack_info);
+  first = static_cast<blas_int>(mplapack_first);
+  last = static_cast<blas_int>(mplapack_last);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trsen(char job, char compq, blas_int* select, blas_int n, uni20::float128* t,
+                                    blas_int ldt, uni20::float128* q, blas_int ldq, uni20::float128* wr,
+                                    uni20::float128* wi, blas_int& selected_dimension,
+                                    uni20::float128& reciprocal_eigenvalue_cluster_condition,
+                                    uni20::float128& reciprocal_invariant_subspace_condition, uni20::float128* work,
+                                    blas_int lwork, blas_int* iwork, blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrsen, job, compq, select, n, t, ldt, q, ldq, wr, wi, selected_dimension,
+                          reciprocal_eigenvalue_cluster_condition, reciprocal_invariant_subspace_condition, work, lwork,
+                          iwork, liwork);
+  mplapackint mplapack_selected_dimension = static_cast<mplapackint>(selected_dimension);
+  mplapackint mplapack_info = 0;
+  blas_int const select_size = std::max<blas_int>(1, n);
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  auto mplapack_select = std::make_unique<bool[]>(static_cast<std::size_t>(select_size));
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    mplapack_select[static_cast<std::size_t>(i)] = select[i] != 0;
+  }
+  Rtrsen(&job, &compq, mplapack_select.get(), static_cast<mplapackint>(n), t, static_cast<mplapackint>(ldt), q,
+         static_cast<mplapackint>(ldq), wr, wi, mplapack_selected_dimension, reciprocal_eigenvalue_cluster_condition,
+         reciprocal_invariant_subspace_condition, work, static_cast<mplapackint>(lwork), mplapack_iwork.data(),
+         static_cast<mplapackint>(liwork), mplapack_info);
+  selected_dimension = static_cast<blas_int>(mplapack_selected_dimension);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    select[i] = mplapack_select[static_cast<std::size_t>(i)] ? 1 : 0;
+  }
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trevc(char side, char howmny, blas_int* select, blas_int n, uni20::float128* t,
+                                    blas_int ldt, uni20::float128* vl, blas_int ldvl, uni20::float128* vr,
+                                    blas_int ldvr, blas_int mm, blas_int& computed_vectors, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrevc, side, howmny, select, n, t, ldt, vl, ldvl, vr, ldvr, mm, computed_vectors,
+                          work);
+  mplapackint mplapack_computed_vectors = static_cast<mplapackint>(computed_vectors);
+  mplapackint mplapack_info = 0;
+  blas_int const select_size = std::max<blas_int>(1, n);
+  auto mplapack_select = std::make_unique<bool[]>(static_cast<std::size_t>(select_size));
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    mplapack_select[static_cast<std::size_t>(i)] = select[i] != 0;
+  }
+  Rtrevc(&side, &howmny, mplapack_select.get(), static_cast<mplapackint>(n), t, static_cast<mplapackint>(ldt), vl,
+         static_cast<mplapackint>(ldvl), vr, static_cast<mplapackint>(ldvr), static_cast<mplapackint>(mm),
+         mplapack_computed_vectors, work, mplapack_info);
+  computed_vectors = static_cast<blas_int>(mplapack_computed_vectors);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    select[i] = mplapack_select[static_cast<std::size_t>(i)] ? 1 : 0;
+  }
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trsna(char job, char howmny, blas_int* select, blas_int n, uni20::float128* t,
+                                    blas_int ldt, uni20::float128* vl, blas_int ldvl, uni20::float128* vr,
+                                    blas_int ldvr, uni20::float128* reciprocal_eigenvalue_condition_numbers,
+                                    uni20::float128* reciprocal_eigenvector_condition_numbers, blas_int mm,
+                                    blas_int& computed_estimates, uni20::float128* work, blas_int ldwork,
+                                    blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrsna, job, howmny, select, n, t, ldt, vl, ldvl, vr, ldvr,
+                          reciprocal_eigenvalue_condition_numbers, reciprocal_eigenvector_condition_numbers, mm,
+                          computed_estimates, work, ldwork, iwork);
+  mplapackint mplapack_computed_estimates = static_cast<mplapackint>(computed_estimates);
+  mplapackint mplapack_info = 0;
+  blas_int const select_size = std::max<blas_int>(1, n);
+  blas_int const iwork_size = std::max<blas_int>(1, 2 * std::max<blas_int>(1, n) - 2);
+  auto mplapack_select = std::make_unique<bool[]>(static_cast<std::size_t>(select_size));
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    mplapack_select[static_cast<std::size_t>(i)] = select[i] != 0;
+  }
+  Rtrsna(&job, &howmny, mplapack_select.get(), static_cast<mplapackint>(n), t, static_cast<mplapackint>(ldt), vl,
+         static_cast<mplapackint>(ldvl), vr, static_cast<mplapackint>(ldvr), reciprocal_eigenvalue_condition_numbers,
+         reciprocal_eigenvector_condition_numbers, static_cast<mplapackint>(mm), mplapack_computed_estimates, work,
+         static_cast<mplapackint>(ldwork), mplapack_iwork.data(), mplapack_info);
+  computed_estimates = static_cast<blas_int>(mplapack_computed_estimates);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    select[i] = mplapack_select[static_cast<std::size_t>(i)] ? 1 : 0;
+  }
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ggev(char jobvl, char jobvr, blas_int n, uni20::float128* a, blas_int lda,
+                                   uni20::float128* b, blas_int ldb, uni20::float128* alphar, uni20::float128* alphai,
+                                   uni20::float128* beta, uni20::float128* vl, blas_int ldvl, uni20::float128* vr,
+                                   blas_int ldvr, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rggev, jobvl, jobvr, n, a, lda, b, ldb, alphar, alphai, beta, vl, ldvl, vr, ldvr,
+                          work, lwork);
+  mplapackint mplapack_info = 0;
+  Rggev(&jobvl, &jobvr, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb),
+        alphar, alphai, beta, vl, static_cast<mplapackint>(ldvl), vr, static_cast<mplapackint>(ldvr), work,
+        static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ggevx(char balanc, char jobvl, char jobvr, char sense, blas_int n, uni20::float128* a,
+                                    blas_int lda, uni20::float128* b, blas_int ldb, uni20::float128* alphar,
+                                    uni20::float128* alphai, uni20::float128* beta, uni20::float128* vl, blas_int ldvl,
+                                    uni20::float128* vr, blas_int ldvr, blas_int& ilo, blas_int& ihi,
+                                    uni20::float128* lscale, uni20::float128* rscale, uni20::float128& abnrm,
+                                    uni20::float128& bbnrm, uni20::float128* rconde, uni20::float128* rcondv,
+                                    uni20::float128* work, blas_int lwork, blas_int* iwork, blas_int* bwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rggevx, balanc, jobvl, jobvr, sense, n, a, lda, b, ldb, alphar, alphai, beta, vl,
+                          ldvl, vr, ldvr, ilo, ihi, lscale, rscale, abnrm, bbnrm, rconde, rcondv, work, lwork, iwork,
+                          bwork);
+  mplapackint mplapack_ilo = static_cast<mplapackint>(ilo);
+  mplapackint mplapack_ihi = static_cast<mplapackint>(ihi);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = std::max<blas_int>(1, n + 6);
+  blas_int const bwork_size = std::max<blas_int>(1, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  auto mplapack_bwork = std::make_unique<bool[]>(static_cast<std::size_t>(bwork_size));
+  for (blas_int i = 0; i < bwork_size; ++i)
+  {
+    mplapack_bwork[static_cast<std::size_t>(i)] = bwork[i] != 0;
+  }
+  Rggevx(&balanc, &jobvl, &jobvr, &sense, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), b,
+         static_cast<mplapackint>(ldb), alphar, alphai, beta, vl, static_cast<mplapackint>(ldvl), vr,
+         static_cast<mplapackint>(ldvr), mplapack_ilo, mplapack_ihi, lscale, rscale, abnrm, bbnrm, rconde, rcondv, work,
+         static_cast<mplapackint>(lwork), mplapack_iwork.data(), mplapack_bwork.get(), mplapack_info);
+  ilo = static_cast<blas_int>(mplapack_ilo);
+  ihi = static_cast<blas_int>(mplapack_ihi);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  for (blas_int i = 0; i < bwork_size; ++i)
+  {
+    bwork[i] = mplapack_bwork[static_cast<std::size_t>(i)] ? 1 : 0;
+  }
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ggbal(char job, blas_int n, uni20::float128* a, blas_int lda, uni20::float128* b,
+                                    blas_int ldb, blas_int& first, blas_int& last, uni20::float128* lscale,
+                                    uni20::float128* rscale, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rggbal, job, n, a, lda, b, ldb, first, last, lscale, rscale, work);
+  mplapackint mplapack_first = static_cast<mplapackint>(first);
+  mplapackint mplapack_last = static_cast<mplapackint>(last);
+  mplapackint mplapack_info = 0;
+  Rggbal(&job, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb),
+         mplapack_first, mplapack_last, lscale, rscale, work, mplapack_info);
+  first = static_cast<blas_int>(mplapack_first);
+  last = static_cast<blas_int>(mplapack_last);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ggbak(char job, char side, blas_int n, blas_int first, blas_int last,
+                                    uni20::float128* lscale, uni20::float128* rscale, blas_int vector_count,
+                                    uni20::float128* vectors, blas_int leading_dimension)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rggbak, job, side, n, first, last, lscale, rscale, vector_count, vectors,
+                          leading_dimension);
+  mplapackint mplapack_info = 0;
+  Rggbak(&job, &side, static_cast<mplapackint>(n), static_cast<mplapackint>(first), static_cast<mplapackint>(last),
+         lscale, rscale, static_cast<mplapackint>(vector_count), vectors, static_cast<mplapackint>(leading_dimension),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gges(char jobvsl, char jobvsr, char sort, blas_int n, uni20::float128* a, blas_int lda,
+                                   uni20::float128* b, blas_int ldb, blas_int& selected_dimension,
+                                   uni20::float128* alphar, uni20::float128* alphai, uni20::float128* beta,
+                                   uni20::float128* vsl, blas_int ldvsl, uni20::float128* vsr, blas_int ldvsr,
+                                   uni20::float128* work, blas_int lwork, blas_int* bwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgges, jobvsl, jobvsr, sort, n, a, lda, b, ldb, selected_dimension, alphar, alphai,
+                          beta, vsl, ldvsl, vsr, ldvsr, work, lwork, bwork);
+  mplapackint mplapack_selected_dimension = static_cast<mplapackint>(selected_dimension);
+  mplapackint mplapack_info = 0;
+  blas_int const bwork_size = std::max<blas_int>(1, n);
+  auto mplapack_bwork = std::make_unique<bool[]>(static_cast<std::size_t>(bwork_size));
+  Rgges(&jobvsl, &jobvsr, &sort, nullptr, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), b,
+        static_cast<mplapackint>(ldb), mplapack_selected_dimension, alphar, alphai, beta, vsl,
+        static_cast<mplapackint>(ldvsl), vsr, static_cast<mplapackint>(ldvsr), work, static_cast<mplapackint>(lwork),
+        mplapack_bwork.get(), mplapack_info);
+  selected_dimension = static_cast<blas_int>(mplapack_selected_dimension);
+  for (blas_int i = 0; i < bwork_size; ++i)
+  {
+    bwork[i] = mplapack_bwork[static_cast<std::size_t>(i)] ? 1 : 0;
+  }
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gghrd(char compq, char compz, blas_int n, blas_int first, blas_int last,
+                                    uni20::float128* a, blas_int lda, uni20::float128* b, blas_int ldb,
+                                    uni20::float128* q, blas_int ldq, uni20::float128* z, blas_int ldz)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgghrd, compq, compz, n, first, last, a, lda, b, ldb, q, ldq, z, ldz);
+  mplapackint mplapack_info = 0;
+  Rgghrd(&compq, &compz, static_cast<mplapackint>(n), static_cast<mplapackint>(first), static_cast<mplapackint>(last),
+         a, static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), q, static_cast<mplapackint>(ldq), z,
+         static_cast<mplapackint>(ldz), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int hgeqz(char job, char compq, char compz, blas_int n, blas_int first, blas_int last,
+                                    uni20::float128* h, blas_int ldh, uni20::float128* t, blas_int ldt,
+                                    uni20::float128* alphar, uni20::float128* alphai, uni20::float128* beta,
+                                    uni20::float128* q, blas_int ldq, uni20::float128* z, blas_int ldz,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rhgeqz, job, compq, compz, n, first, last, h, ldh, t, ldt, alphar, alphai, beta, q,
+                          ldq, z, ldz, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rhgeqz(&job, &compq, &compz, static_cast<mplapackint>(n), static_cast<mplapackint>(first),
+         static_cast<mplapackint>(last), h, static_cast<mplapackint>(ldh), t, static_cast<mplapackint>(ldt), alphar,
+         alphai, beta, q, static_cast<mplapackint>(ldq), z, static_cast<mplapackint>(ldz), work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int tgexc(bool wantq, bool wantz, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128* b, blas_int ldb, uni20::float128* q, blas_int ldq,
+                                    uni20::float128* z, blas_int ldz, blas_int& first, blas_int& last,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtgexc, wantq, wantz, n, a, lda, b, ldb, q, ldq, z, ldz, first, last, work, lwork);
+  mplapackint mplapack_first = static_cast<mplapackint>(first);
+  mplapackint mplapack_last = static_cast<mplapackint>(last);
+  mplapackint mplapack_info = 0;
+  Rtgexc(wantq, wantz, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb),
+         q, static_cast<mplapackint>(ldq), z, static_cast<mplapackint>(ldz), mplapack_first, mplapack_last, work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  first = static_cast<blas_int>(mplapack_first);
+  last = static_cast<blas_int>(mplapack_last);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int tgsen(blas_int ijob, bool wantq, bool wantz, blas_int* select, blas_int n,
+                                    uni20::float128* a, blas_int lda, uni20::float128* b, blas_int ldb,
+                                    uni20::float128* alphar, uni20::float128* alphai, uni20::float128* beta,
+                                    uni20::float128* q, blas_int ldq, uni20::float128* z, blas_int ldz,
+                                    blas_int& selected_dimension, uni20::float128& pl, uni20::float128& pr,
+                                    uni20::float128* dif, uni20::float128* work, blas_int lwork, blas_int* iwork,
+                                    blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtgsen, ijob, wantq, wantz, select, n, a, lda, b, ldb, alphar, alphai, beta, q, ldq,
+                          z, ldz, selected_dimension, pl, pr, dif, work, lwork, iwork, liwork);
+  mplapackint mplapack_selected_dimension = static_cast<mplapackint>(selected_dimension);
+  mplapackint mplapack_info = 0;
+  blas_int const select_size = std::max<blas_int>(1, n);
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  auto mplapack_select = std::make_unique<bool[]>(static_cast<std::size_t>(select_size));
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    mplapack_select[static_cast<std::size_t>(i)] = select[i] != 0;
+  }
+  Rtgsen(static_cast<mplapackint>(ijob), wantq, wantz, mplapack_select.get(), static_cast<mplapackint>(n), a,
+         static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), alphar, alphai, beta, q,
+         static_cast<mplapackint>(ldq), z, static_cast<mplapackint>(ldz), mplapack_selected_dimension, pl, pr, dif,
+         work, static_cast<mplapackint>(lwork), mplapack_iwork.data(), static_cast<mplapackint>(liwork), mplapack_info);
+  selected_dimension = static_cast<blas_int>(mplapack_selected_dimension);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    select[i] = mplapack_select[static_cast<std::size_t>(i)] ? 1 : 0;
+  }
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int tgevc(char side, char howmny, blas_int* select, blas_int n, uni20::float128* s,
+                                    blas_int lds, uni20::float128* p, blas_int ldp, uni20::float128* vl, blas_int ldvl,
+                                    uni20::float128* vr, blas_int ldvr, blas_int mm, blas_int& computed_vectors,
+                                    uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtgevc, side, howmny, select, n, s, lds, p, ldp, vl, ldvl, vr, ldvr, mm,
+                          computed_vectors, work);
+  mplapackint mplapack_computed_vectors = static_cast<mplapackint>(computed_vectors);
+  mplapackint mplapack_info = 0;
+  blas_int const select_size = std::max<blas_int>(1, n);
+  auto mplapack_select = std::make_unique<bool[]>(static_cast<std::size_t>(select_size));
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    mplapack_select[static_cast<std::size_t>(i)] = select[i] != 0;
+  }
+  Rtgevc(&side, &howmny, mplapack_select.get(), static_cast<mplapackint>(n), s, static_cast<mplapackint>(lds), p,
+         static_cast<mplapackint>(ldp), vl, static_cast<mplapackint>(ldvl), vr, static_cast<mplapackint>(ldvr),
+         static_cast<mplapackint>(mm), mplapack_computed_vectors, work, mplapack_info);
+  computed_vectors = static_cast<blas_int>(mplapack_computed_vectors);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    select[i] = mplapack_select[static_cast<std::size_t>(i)] ? 1 : 0;
+  }
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int tgsna(char job, char howmny, blas_int* select, blas_int n, uni20::float128* a,
+                                    blas_int lda, uni20::float128* b, blas_int ldb, uni20::float128* vl, blas_int ldvl,
+                                    uni20::float128* vr, blas_int ldvr,
+                                    uni20::float128* reciprocal_eigenvalue_condition_numbers,
+                                    uni20::float128* reciprocal_eigenvector_condition_numbers, blas_int mm,
+                                    blas_int& computed_estimates, uni20::float128* work, blas_int lwork,
+                                    blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtgsna, job, howmny, select, n, a, lda, b, ldb, vl, ldvl, vr, ldvr,
+                          reciprocal_eigenvalue_condition_numbers, reciprocal_eigenvector_condition_numbers, mm,
+                          computed_estimates, work, lwork, iwork);
+  mplapackint mplapack_computed_estimates = static_cast<mplapackint>(computed_estimates);
+  mplapackint mplapack_info = 0;
+  blas_int const select_size = std::max<blas_int>(1, n);
+  blas_int const iwork_size = std::max<blas_int>(1, n + 6);
+  auto mplapack_select = std::make_unique<bool[]>(static_cast<std::size_t>(select_size));
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    mplapack_select[static_cast<std::size_t>(i)] = select[i] != 0;
+  }
+  Rtgsna(&job, &howmny, mplapack_select.get(), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), b,
+         static_cast<mplapackint>(ldb), vl, static_cast<mplapackint>(ldvl), vr, static_cast<mplapackint>(ldvr),
+         reciprocal_eigenvalue_condition_numbers, reciprocal_eigenvector_condition_numbers,
+         static_cast<mplapackint>(mm), mplapack_computed_estimates, work, static_cast<mplapackint>(lwork),
+         mplapack_iwork.data(), mplapack_info);
+  computed_estimates = static_cast<blas_int>(mplapack_computed_estimates);
+  for (blas_int i = 0; i < select_size; ++i)
+  {
+    select[i] = mplapack_select[static_cast<std::size_t>(i)] ? 1 : 0;
+  }
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int orgbr(char vect, blas_int m, blas_int n, blas_int k, uni20::float128* a, blas_int lda,
+                                    uni20::float128* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rorgbr, vect, m, n, k, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rorgbr(&vect, static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int orghr(blas_int n, blas_int first, blas_int last, uni20::float128* a, blas_int lda,
+                                    uni20::float128 const* tau, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rorghr, n, first, last, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rorghr(static_cast<mplapackint>(n), static_cast<mplapackint>(first), static_cast<mplapackint>(last), a,
+         static_cast<mplapackint>(lda), const_cast<uni20::float128*>(tau), work, static_cast<mplapackint>(lwork),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int orgtr(char uplo, blas_int n, uni20::float128* a, blas_int lda, uni20::float128 const* tau,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rorgtr, uplo, n, a, lda, tau, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rorgtr(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), const_cast<uni20::float128*>(tau), work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ormhr(char side, char trans, blas_int m, blas_int n, blas_int first, blas_int last,
+                                    uni20::float128* a, blas_int lda, uni20::float128 const* tau, uni20::float128* c,
+                                    blas_int ldc, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rormhr, side, trans, m, n, first, last, a, lda, tau, c, ldc, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rormhr(&side, &trans, static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(first),
+         static_cast<mplapackint>(last), a, static_cast<mplapackint>(lda), const_cast<uni20::float128*>(tau), c,
+         static_cast<mplapackint>(ldc), work, static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ormtr(char side, char uplo, char trans, blas_int m, blas_int n, uni20::float128* a,
+                                    blas_int lda, uni20::float128 const* tau, uni20::float128* c, blas_int ldc,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rormtr, side, uplo, trans, m, n, a, lda, tau, c, ldc, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rormtr(&side, &uplo, &trans, static_cast<mplapackint>(m), static_cast<mplapackint>(n), a,
+         static_cast<mplapackint>(lda), const_cast<uni20::float128*>(tau), c, static_cast<mplapackint>(ldc), work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ormbr(char vect, char side, char trans, blas_int m, blas_int n, blas_int k,
+                                    uni20::float128* a, blas_int lda, uni20::float128* tau, uni20::float128* c,
+                                    blas_int ldc, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rormbr, vect, side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rormbr(&vect, &side, &trans, static_cast<mplapackint>(m), static_cast<mplapackint>(n), static_cast<mplapackint>(k), a,
+         static_cast<mplapackint>(lda), tau, c, static_cast<mplapackint>(ldc), work, static_cast<mplapackint>(lwork),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gesvd(char jobu, char jobvt, blas_int m, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128* s, uni20::float128* u, blas_int ldu, uni20::float128* vt,
+                                    blas_int ldvt, uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgesvd, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork);
+  mplapackint mplapack_info = 0;
+  Rgesvd(&jobu, &jobvt, static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), s,
+         u, static_cast<mplapackint>(ldu), vt, static_cast<mplapackint>(ldvt), work, static_cast<mplapackint>(lwork),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gesdd(char jobz, blas_int m, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128* s, uni20::float128* u, blas_int ldu, uni20::float128* vt,
+                                    blas_int ldvt, uni20::float128* work, blas_int lwork, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgesdd, jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(8 * std::min(m, n));
+  Rgesdd(&jobz, static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), s, u,
+         static_cast<mplapackint>(ldu), vt, static_cast<mplapackint>(ldvt), work, static_cast<mplapackint>(lwork),
+         mplapack_iwork.data(), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gesvdx(char jobu, char jobvt, char range, blas_int m, blas_int n, uni20::float128* a,
+                                     blas_int lda, uni20::float128 vl, uni20::float128 vu, blas_int il, blas_int iu,
+                                     blas_int& selected_count, uni20::float128* singular_values, uni20::float128* u,
+                                     blas_int ldu, uni20::float128* vt, blas_int ldvt, uni20::float128* work,
+                                     blas_int lwork, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgesvdx, jobu, jobvt, range, m, n, a, lda, vl, vu, il, iu, selected_count,
+                          singular_values, u, ldu, vt, ldvt, work, lwork, iwork);
+  mplapackint mplapack_selected_count = static_cast<mplapackint>(selected_count);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = 12 * std::max<blas_int>(1, std::min(m, n));
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rgesvdx(&jobu, &jobvt, &range, static_cast<mplapackint>(m), static_cast<mplapackint>(n), a,
+          static_cast<mplapackint>(lda), vl, vu, static_cast<mplapackint>(il), static_cast<mplapackint>(iu),
+          mplapack_selected_count, singular_values, u, static_cast<mplapackint>(ldu), vt,
+          static_cast<mplapackint>(ldvt), work, static_cast<mplapackint>(lwork), mplapack_iwork.data(), mplapack_info);
+  selected_count = static_cast<blas_int>(mplapack_selected_count);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int bdsqr(char uplo, blas_int n, blas_int ncvt, blas_int nru, blas_int ncc,
+                                    uni20::float128* d, uni20::float128* e, uni20::float128* vt, blas_int ldvt,
+                                    uni20::float128* u, blas_int ldu, uni20::float128* c, blas_int ldc,
+                                    uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rbdsqr, uplo, n, ncvt, nru, ncc, d, e, vt, ldvt, u, ldu, c, ldc, work);
+  mplapackint mplapack_info = 0;
+  Rbdsqr(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(ncvt), static_cast<mplapackint>(nru),
+         static_cast<mplapackint>(ncc), d, e, vt, static_cast<mplapackint>(ldvt), u, static_cast<mplapackint>(ldu), c,
+         static_cast<mplapackint>(ldc), work, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int bdsdc(char uplo, char compq, blas_int n, uni20::float128* d, uni20::float128* e,
+                                    uni20::float128* u, blas_int ldu, uni20::float128* vt, blas_int ldvt,
+                                    uni20::float128* q, blas_int* iq, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rbdsdc, uplo, compq, n, d, e, u, ldu, vt, ldvt, q, iq, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iq = uni20::lapack::mplapack::detail::to_mplapack_ints(iq, 1);
+  blas_int const iwork_size = 8 * std::max<blas_int>(1, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rbdsdc(&uplo, &compq, static_cast<mplapackint>(n), d, e, u, static_cast<mplapackint>(ldu), vt,
+         static_cast<mplapackint>(ldvt), q, mplapack_iq.data(), work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iq, iq, 1);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int bdsvdx(char uplo, char jobz, char range, blas_int n, uni20::float128* d,
+                                     uni20::float128* e, uni20::float128 vl, uni20::float128 vu, blas_int il,
+                                     blas_int iu, blas_int& selected_count, uni20::float128* singular_values,
+                                     uni20::float128* z, blas_int ldz, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rbdsvdx, uplo, jobz, range, n, d, e, vl, vu, il, iu, selected_count, singular_values,
+                          z, ldz, work, iwork);
+  mplapackint mplapack_selected_count = static_cast<mplapackint>(selected_count);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = 12 * std::max<blas_int>(1, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rbdsvdx(&uplo, &jobz, &range, static_cast<mplapackint>(n), d, e, vl, vu, static_cast<mplapackint>(il),
+          static_cast<mplapackint>(iu), mplapack_selected_count, singular_values, z, static_cast<mplapackint>(ldz),
+          work, mplapack_iwork.data(), mplapack_info);
+  selected_count = static_cast<blas_int>(mplapack_selected_count);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int potrf(char uplo, blas_int n, uni20::float128* a, blas_int lda)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpotrf, uplo, n, a, lda);
+  mplapackint mplapack_info = 0;
+  Rpotrf(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pstrf(char uplo, blas_int n, uni20::float128* a, blas_int lda, blas_int* pivots,
+                                    blas_int& rank, uni20::float128 tolerance, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpstrf, uplo, n, a, lda, pivots, rank, tolerance, work);
+  mplapackint mplapack_rank = static_cast<mplapackint>(rank);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_pivots = uni20::lapack::mplapack::detail::to_mplapack_ints(pivots, n);
+  Rpstrf(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_pivots.data(), mplapack_rank,
+         tolerance, work, mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_pivots, pivots, n);
+  rank = static_cast<blas_int>(mplapack_rank);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int potri(char uplo, blas_int n, uni20::float128* a, blas_int lda)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpotri, uplo, n, a, lda);
+  mplapackint mplapack_info = 0;
+  Rpotri(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int potrs(char uplo, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpotrs, uplo, n, nrhs, a, lda, b, ldb);
+  mplapackint mplapack_info = 0;
+  Rpotrs(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda), b,
+         static_cast<mplapackint>(ldb), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int porfs(char uplo, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* factors, blas_int factor_lda, uni20::float128* b, blas_int ldb,
+                                    uni20::float128* x, blas_int ldx, uni20::float128* forward_error,
+                                    uni20::float128* backward_error, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rporfs, uplo, n, nrhs, a, lda, factors, factor_lda, b, ldb, x, ldx, forward_error,
+                          backward_error, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rporfs(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda), factors,
+         static_cast<mplapackint>(factor_lda), b, static_cast<mplapackint>(ldb), x, static_cast<mplapackint>(ldx),
+         forward_error, backward_error, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int posvx(char fact, char uplo, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* af, blas_int ldaf, char& equed, uni20::float128* scale,
+                                    uni20::float128* b, blas_int ldb, uni20::float128* x, blas_int ldx,
+                                    uni20::float128& rcond, uni20::float128* forward_error,
+                                    uni20::float128* backward_error, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rposvx, fact, uplo, n, nrhs, a, lda, af, ldaf, equed, scale, b, ldb, x, ldx, work,
+                          iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rposvx(&fact, &uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda),
+         af, static_cast<mplapackint>(ldaf), &equed, scale, b, static_cast<mplapackint>(ldb), x,
+         static_cast<mplapackint>(ldx), rcond, forward_error, backward_error, work, mplapack_iwork.data(),
+         mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int poequ(blas_int n, uni20::float128* a, blas_int lda, uni20::float128* scale,
+                                    uni20::float128& scale_condition, uni20::float128& max_abs)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpoequ, n, a, lda, scale);
+  mplapackint mplapack_info = 0;
+  Rpoequ(static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), scale, scale_condition, max_abs, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pocon(char uplo, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128 matrix_one_norm, uni20::float128& rcond, uni20::float128* work,
+                                    blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpocon, uplo, n, a, lda, matrix_one_norm, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rpocon(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), matrix_one_norm, rcond, work,
+         mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sytrf(char uplo, blas_int n, uni20::float128* a, blas_int lda, blas_int* ipiv,
+                                    uni20::float128* work, blas_int lwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsytrf, uplo, n, a, lda, ipiv, work, lwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rsytrf(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_ipiv.data(), work,
+         static_cast<mplapackint>(lwork), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sytrs(char uplo, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    blas_int const* ipiv, uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsytrs, uplo, n, nrhs, a, lda, ipiv, b, ldb);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  Rsytrs(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda),
+         mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sytri(char uplo, blas_int n, uni20::float128* a, blas_int lda, blas_int const* ipiv,
+                                    uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsytri, uplo, n, a, lda, ipiv, work);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  Rsytri(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_ipiv.data(), work,
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int syrfs(char uplo, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* factors, blas_int factor_lda, blas_int const* ipiv,
+                                    uni20::float128* b, blas_int ldb, uni20::float128* x, blas_int ldx,
+                                    uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsyrfs, uplo, n, nrhs, a, lda, factors, factor_lda, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rsyrfs(&uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda), factors,
+         static_cast<mplapackint>(factor_lda), mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), x,
+         static_cast<mplapackint>(ldx), forward_error, backward_error, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sysvx(char fact, char uplo, blas_int n, blas_int nrhs, uni20::float128* a, blas_int lda,
+                                    uni20::float128* af, blas_int ldaf, blas_int* ipiv, uni20::float128* b,
+                                    blas_int ldb, uni20::float128* x, blas_int ldx, uni20::float128& rcond,
+                                    uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work, blas_int lwork, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsysvx, fact, uplo, n, nrhs, a, lda, af, ldaf, ipiv, b, ldb, x, ldx, work, lwork,
+                          iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rsysvx(&fact, &uplo, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a, static_cast<mplapackint>(lda),
+         af, static_cast<mplapackint>(ldaf), mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), x,
+         static_cast<mplapackint>(ldx), rcond, forward_error, backward_error, work, static_cast<mplapackint>(lwork),
+         mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, n);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sycon(char uplo, blas_int n, uni20::float128* a, blas_int lda, blas_int const* ipiv,
+                                    uni20::float128 matrix_one_norm, uni20::float128& rcond, uni20::float128* work,
+                                    blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsycon, uplo, n, a, lda, ipiv, matrix_one_norm, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rsycon(&uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_ipiv.data(), matrix_one_norm,
+         rcond, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trtrs(char uplo, char trans, char diag, blas_int n, blas_int nrhs, uni20::float128* a,
+                                    blas_int lda, uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrtrs, uplo, trans, diag, n, nrhs, a, lda, b, ldb);
+  mplapackint mplapack_info = 0;
+  Rtrtrs(&uplo, &trans, &diag, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a,
+         static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trrfs(char uplo, char trans, char diag, blas_int n, blas_int nrhs, uni20::float128* a,
+                                    blas_int lda, uni20::float128* b, blas_int ldb, uni20::float128* x, blas_int ldx,
+                                    uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrrfs, uplo, trans, diag, n, nrhs, a, lda, b, ldb, x, ldx, forward_error,
+                          backward_error, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rtrrfs(&uplo, &trans, &diag, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), a,
+         static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), x, static_cast<mplapackint>(ldx),
+         forward_error, backward_error, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trtri(char uplo, char diag, blas_int n, uni20::float128* a, blas_int lda)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrtri, uplo, diag, n, a, lda);
+  mplapackint mplapack_info = 0;
+  Rtrtri(&uplo, &diag, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trcon(char norm, char uplo, char diag, blas_int n, uni20::float128* a, blas_int lda,
+                                    uni20::float128& rcond, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrcon, norm, uplo, diag, n, a, lda, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rtrcon(&norm, &uplo, &diag, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), rcond, work,
+         mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int trsyl(char trans_a, char trans_b, blas_int sign, blas_int m, blas_int n,
+                                    uni20::float128* a, blas_int lda, uni20::float128* b, blas_int ldb,
+                                    uni20::float128* c, blas_int ldc, uni20::float128& scale)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rtrsyl, trans_a, trans_b, sign, m, n, a, lda, b, ldb, c, ldc);
+  mplapackint mplapack_info = 0;
+  Rtrsyl(&trans_a, &trans_b, static_cast<mplapackint>(sign), static_cast<mplapackint>(m), static_cast<mplapackint>(n),
+         a, static_cast<mplapackint>(lda), b, static_cast<mplapackint>(ldb), c, static_cast<mplapackint>(ldc), scale,
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+} // namespace uni20::lapack::unchecked

--- a/src/uni20/backend/lapack/mplapack/norms.hpp
+++ b/src/uni20/backend/lapack/mplapack/norms.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+/**
+ * \defgroup backend_lapack_mplapack MPLAPACK backend
+ * \ingroup backend_lapack
+ * \brief Header-only wrappers around configured MPLAPACK extension-precision routines.
+ */
+
+/**
+ * \file norms.hpp
+ * \ingroup backend_lapack_mplapack
+ * \brief MPLAPACK binary128 norm wrappers.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/backend/lapack/common.hpp>
+#include <uni20/config.hpp>
+#include <uni20/core/types.hpp>
+
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
+// clang-format off
+#include <mplapack_config.h>
+#include <mplapack_binary128.h>
+// clang-format on
+#endif
+
+namespace uni20::lapack::unchecked
+{
+
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
+
+[[nodiscard]] inline uni20::float128 lange(char norm, blas_int m, blas_int n, uni20::float128* a, blas_int lda,
+                                           uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rlange, norm, m, n, a, lda, work);
+  return Rlange(&norm, static_cast<mplapackint>(m), static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda),
+                work);
+}
+
+[[nodiscard]] inline uni20::float128 lansy(char norm, char uplo, blas_int n, uni20::float128* a, blas_int lda,
+                                           uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rlansy, norm, uplo, n, a, lda, work);
+  return Rlansy(&norm, &uplo, static_cast<mplapackint>(n), a, static_cast<mplapackint>(lda), work);
+}
+
+[[nodiscard]] inline uni20::float128 lantr(char norm, char uplo, char diag, blas_int m, blas_int n, uni20::float128* a,
+                                           blas_int lda, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rlantr, norm, uplo, diag, m, n, a, lda, work);
+  return Rlantr(&norm, &uplo, &diag, static_cast<mplapackint>(m), static_cast<mplapackint>(n), a,
+                static_cast<mplapackint>(lda), work);
+}
+
+[[nodiscard]] inline uni20::float128 langb(char norm, blas_int n, blas_int kl, blas_int ku, uni20::float128* ab,
+                                           blas_int ldab, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rlangb, norm, n, kl, ku, ab, ldab, work);
+  return Rlangb(&norm, static_cast<mplapackint>(n), static_cast<mplapackint>(kl), static_cast<mplapackint>(ku), ab,
+                static_cast<mplapackint>(ldab), work);
+}
+
+#endif
+
+} // namespace uni20::lapack::unchecked

--- a/src/uni20/backend/lapack/mplapack/tridiagonal.hpp
+++ b/src/uni20/backend/lapack/mplapack/tridiagonal.hpp
@@ -1,0 +1,231 @@
+#pragma once
+
+/**
+ * \file tridiagonal.hpp
+ * \ingroup backend_lapack_mplapack
+ * \brief MPLAPACK binary128 wrappers for real tridiagonal linear algebra.
+ */
+
+#include <uni20/backend/backend.hpp>
+#include <uni20/backend/lapack/common.hpp>
+#include <uni20/backend/lapack/mplapack/common.hpp>
+#include <uni20/config.hpp>
+#include <uni20/core/types.hpp>
+
+#if !(UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK)
+#error "uni20/backend/lapack/mplapack/tridiagonal.hpp requires MPLAPACK float128 support"
+#endif
+
+// clang-format off
+#include <mplapack_config.h>
+#include <mplapack_binary128.h>
+// clang-format on
+
+namespace uni20::lapack::unchecked
+{
+
+[[nodiscard]] inline blas_int gtsv(blas_int n, blas_int nrhs, uni20::float128* dl, uni20::float128* d,
+                                   uni20::float128* du, uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgtsv, n, nrhs, dl, d, du, b, ldb);
+  mplapackint mplapack_info = 0;
+  Rgtsv(static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), dl, d, du, b, static_cast<mplapackint>(ldb),
+        mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gttrf(blas_int n, uni20::float128* dl, uni20::float128* d, uni20::float128* du,
+                                    uni20::float128* du2, blas_int* ipiv)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgttrf, n, dl, d, du, du2, ipiv);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgttrf(static_cast<mplapackint>(n), dl, d, du, du2, mplapack_ipiv.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gttrs(char trans, blas_int n, blas_int nrhs, uni20::float128* dl, uni20::float128* d,
+                                    uni20::float128* du, uni20::float128* du2, blas_int const* ipiv, uni20::float128* b,
+                                    blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgttrs, trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  Rgttrs(&trans, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), dl, d, du, du2, mplapack_ipiv.data(), b,
+         static_cast<mplapackint>(ldb), mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gtcon(char norm, blas_int n, uni20::float128* dl, uni20::float128* d, uni20::float128* du,
+                                    uni20::float128* du2, blas_int const* ipiv, uni20::float128 matrix_norm,
+                                    uni20::float128& rcond, uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgtcon, norm, n, dl, d, du, du2, ipiv, matrix_norm, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgtcon(&norm, static_cast<mplapackint>(n), dl, d, du, du2, mplapack_ipiv.data(), matrix_norm, rcond, work,
+         mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gtrfs(char trans, blas_int n, blas_int nrhs, uni20::float128* dl, uni20::float128* d,
+                                    uni20::float128* du, uni20::float128* dlf, uni20::float128* df,
+                                    uni20::float128* duf, uni20::float128* du2, blas_int const* ipiv,
+                                    uni20::float128* b, blas_int ldb, uni20::float128* x, blas_int ldx,
+                                    uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgtrfs, trans, n, nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, ldb, x, ldx,
+                          forward_error, backward_error, work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgtrfs(&trans, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), dl, d, du, dlf, df, duf, du2,
+         mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), x, static_cast<mplapackint>(ldx), forward_error,
+         backward_error, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int gtsvx(char fact, char trans, blas_int n, blas_int nrhs, uni20::float128* dl,
+                                    uni20::float128* d, uni20::float128* du, uni20::float128* dlf, uni20::float128* df,
+                                    uni20::float128* duf, uni20::float128* du2, blas_int* ipiv, uni20::float128* b,
+                                    blas_int ldb, uni20::float128* x, blas_int ldx, uni20::float128& rcond,
+                                    uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work, blas_int* iwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rgtsvx, fact, trans, n, nrhs, dl, d, du, dlf, df, duf, du2, ipiv, b, ldb, x, ldx,
+                          work, iwork);
+  mplapackint mplapack_info = 0;
+  std::vector<mplapackint> mplapack_ipiv = uni20::lapack::mplapack::detail::to_mplapack_ints(ipiv, n);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::make_mplapack_int_work(n);
+  Rgtsvx(&fact, &trans, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), dl, d, du, dlf, df, duf, du2,
+         mplapack_ipiv.data(), b, static_cast<mplapackint>(ldb), x, static_cast<mplapackint>(ldx), rcond, forward_error,
+         backward_error, work, mplapack_iwork.data(), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_ipiv, ipiv, n);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, n);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ptsv(blas_int n, blas_int nrhs, uni20::float128* d, uni20::float128* e,
+                                   uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rptsv, n, nrhs, d, e, b, ldb);
+  mplapackint mplapack_info = 0;
+  Rptsv(static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), d, e, b, static_cast<mplapackint>(ldb),
+        mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pttrf(blas_int n, uni20::float128* d, uni20::float128* e)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpttrf, n, d, e);
+  mplapackint mplapack_info = 0;
+  Rpttrf(static_cast<mplapackint>(n), d, e, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int pttrs(blas_int n, blas_int nrhs, uni20::float128* d, uni20::float128* e,
+                                    uni20::float128* b, blas_int ldb)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rpttrs, n, nrhs, d, e, b, ldb);
+  mplapackint mplapack_info = 0;
+  Rpttrs(static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), d, e, b, static_cast<mplapackint>(ldb),
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ptcon(blas_int n, uni20::float128* d, uni20::float128* e, uni20::float128 matrix_norm,
+                                    uni20::float128& rcond, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rptcon, n, d, e, matrix_norm, work);
+  mplapackint mplapack_info = 0;
+  Rptcon(static_cast<mplapackint>(n), d, e, matrix_norm, rcond, work, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ptrfs(blas_int n, blas_int nrhs, uni20::float128* d, uni20::float128* e,
+                                    uni20::float128* df, uni20::float128* ef, uni20::float128* b, blas_int ldb,
+                                    uni20::float128* x, blas_int ldx, uni20::float128* forward_error,
+                                    uni20::float128* backward_error, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rptrfs, n, nrhs, d, e, df, ef, b, ldb, x, ldx, forward_error, backward_error, work);
+  mplapackint mplapack_info = 0;
+  Rptrfs(static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), d, e, df, ef, b, static_cast<mplapackint>(ldb), x,
+         static_cast<mplapackint>(ldx), forward_error, backward_error, work, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int ptsvx(char fact, blas_int n, blas_int nrhs, uni20::float128* d, uni20::float128* e,
+                                    uni20::float128* df, uni20::float128* ef, uni20::float128* b, blas_int ldb,
+                                    uni20::float128* x, blas_int ldx, uni20::float128& rcond,
+                                    uni20::float128* forward_error, uni20::float128* backward_error,
+                                    uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rptsvx, fact, n, nrhs, d, e, df, ef, b, ldb, x, ldx, work);
+  mplapackint mplapack_info = 0;
+  Rptsvx(&fact, static_cast<mplapackint>(n), static_cast<mplapackint>(nrhs), d, e, df, ef, b,
+         static_cast<mplapackint>(ldb), x, static_cast<mplapackint>(ldx), rcond, forward_error, backward_error, work,
+         mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int sterf(blas_int n, uni20::float128* d, uni20::float128* e)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsterf, n, d, e);
+  mplapackint mplapack_info = 0;
+  Rsterf(static_cast<mplapackint>(n), d, e, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int steqr(char compz, blas_int n, uni20::float128* d, uni20::float128* e, uni20::float128* z,
+                                    blas_int ldz, uni20::float128* work)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rsteqr, compz, n, d, e, z, ldz, work);
+  mplapackint mplapack_info = 0;
+  Rsteqr(&compz, static_cast<mplapackint>(n), d, e, z, static_cast<mplapackint>(ldz), work, mplapack_info);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int stevd(char jobz, blas_int n, uni20::float128* d, uni20::float128* e, uni20::float128* z,
+                                    blas_int ldz, uni20::float128* work, blas_int lwork, blas_int* iwork,
+                                    blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rstevd, jobz, n, d, e, z, ldz, work, lwork, iwork, liwork);
+  mplapackint mplapack_info = 0;
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rstevd(&jobz, static_cast<mplapackint>(n), d, e, z, static_cast<mplapackint>(ldz), work,
+         static_cast<mplapackint>(lwork), mplapack_iwork.data(), static_cast<mplapackint>(liwork), mplapack_info);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+[[nodiscard]] inline blas_int stevr(char jobz, char range, blas_int n, uni20::float128* d, uni20::float128* e,
+                                    uni20::float128 vl, uni20::float128 vu, blas_int il, blas_int iu,
+                                    uni20::float128 abstol, blas_int& selected_count, uni20::float128* w,
+                                    uni20::float128* z, blas_int ldz, blas_int* isuppz, uni20::float128* work,
+                                    blas_int lwork, blas_int* iwork, blas_int liwork)
+{
+  UNI20_EXTERNAL_API_CALL(LAPACK, Rstevr, jobz, range, n, d, e, vl, vu, il, iu, abstol, selected_count, w, z, ldz,
+                          isuppz, work, lwork, iwork, liwork);
+  mplapackint mplapack_selected_count = static_cast<mplapackint>(selected_count);
+  mplapackint mplapack_info = 0;
+  blas_int const support_size = 2 * std::max<blas_int>(1, n);
+  blas_int const iwork_size = std::max<blas_int>(1, liwork == -1 ? blas_int{1} : liwork);
+  std::vector<mplapackint> mplapack_isuppz = uni20::lapack::mplapack::detail::to_mplapack_ints(isuppz, support_size);
+  std::vector<mplapackint> mplapack_iwork = uni20::lapack::mplapack::detail::to_mplapack_ints(iwork, iwork_size);
+  Rstevr(&jobz, &range, static_cast<mplapackint>(n), d, e, vl, vu, static_cast<mplapackint>(il),
+         static_cast<mplapackint>(iu), abstol, mplapack_selected_count, w, z, static_cast<mplapackint>(ldz),
+         mplapack_isuppz.data(), work, static_cast<mplapackint>(lwork), mplapack_iwork.data(),
+         static_cast<mplapackint>(liwork), mplapack_info);
+  selected_count = static_cast<blas_int>(mplapack_selected_count);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_isuppz, isuppz, support_size);
+  uni20::lapack::mplapack::detail::copy_from_mplapack_ints(mplapack_iwork, iwork, iwork_size);
+  return static_cast<blas_int>(mplapack_info);
+}
+
+} // namespace uni20::lapack::unchecked

--- a/src/uni20/config.hpp.in
+++ b/src/uni20/config.hpp.in
@@ -36,6 +36,10 @@
 
 #cmakedefine01 UNI20_ILP64
 
+// Optional scalar precision configuration.
+#cmakedefine01 UNI20_HAS_FLOAT128
+#cmakedefine01 UNI20_FLOAT128_PROVIDER_MPLAPACK
+
 #define UNI20_BLAS_VENDOR "@UNI20_DETECTED_BLAS_VENDOR@"
 
 #define @UNI20_DETECTED_BLAS_VENDOR_MACRO@ 1

--- a/src/uni20/core/scalar_concepts.hpp
+++ b/src/uni20/core/scalar_concepts.hpp
@@ -28,9 +28,11 @@ inline constexpr bool has_builtin_lapack_complex_backend_v = std::same_as<T, cfl
 template <typename T> inline constexpr bool has_mplapack_lapack_complex_backend_v = false;
 
 #if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
 template <> inline constexpr bool has_mplapack_blas_real_backend_v<uni20::float128> = true;
 
 template <> inline constexpr bool has_mplapack_blas_complex_backend_v<uni20::complex<uni20::float128>> = true;
+#endif
 
 template <> inline constexpr bool has_mplapack_lapack_real_backend_v<uni20::float128> = true;
 

--- a/src/uni20/linalg/backends/cpu/matrix_exponential.cpp
+++ b/src/uni20/linalg/backends/cpu/matrix_exponential.cpp
@@ -592,7 +592,7 @@ template DenseMatrix<uni20::complex<double>> matrix_exponential(DenseMatrix<uni2
 template DenseMatrix<uni20::complex<long double>> matrix_exponential(DenseMatrix<uni20::complex<long double>> const&,
                                                                      uni20::complex<long double>);
 
-#if defined(UNI20_ENABLE_MPLAPACK) && defined(MPLAPACK_BINARY128_MODE) &&                                              \
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK && defined(MPLAPACK_BINARY128_MODE) &&                      \
     (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
 template DenseMatrix<mplapack_binary128_t> matrix_exponential(DenseMatrix<mplapack_binary128_t> const&,
                                                               mplapack_binary128_t);

--- a/src/uni20/linalg/backends/cpu/matrix_exponential.hpp
+++ b/src/uni20/linalg/backends/cpu/matrix_exponential.hpp
@@ -5,7 +5,9 @@
 
 #pragma once
 
-#if defined(UNI20_ENABLE_MPLAPACK)
+#include <uni20/config.hpp>
+
+#if UNI20_HAS_FLOAT128 && UNI20_FLOAT128_PROVIDER_MPLAPACK
 #include <mplapack_config.h>
 #endif
 #include <complex>

--- a/tests/core/test_mplapack_binary128.cpp
+++ b/tests/core/test_mplapack_binary128.cpp
@@ -1,0 +1,203 @@
+#include <uni20/backend/blas/backend_blas.hpp>
+#include <uni20/core/numeric_limits.hpp>
+#include <uni20/core/scalar_concepts.hpp>
+#include <uni20/core/scalar_io.hpp>
+
+#include <fmt/format.h>
+#include <mplapack_binary128.h>
+#include <mplapack_config.h>
+
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
+#include <mpblas_binary128.h>
+#endif
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <sstream>
+#include <type_traits>
+#include <vector>
+
+namespace
+{
+
+using Binary128 = uni20::float128;
+using ComplexBinary128 = uni20::complex<Binary128>;
+
+Binary128 abs_error(Binary128 actual, Binary128 expected) { return std::abs(actual - expected); }
+
+Binary128 binary_power_of_two(int exponent)
+{
+  Binary128 result{1};
+  if (exponent >= 0)
+  {
+    for (int i = 0; i < exponent; ++i)
+    {
+      result *= Binary128{2};
+    }
+  }
+  else
+  {
+    for (int i = 0; i < -exponent; ++i)
+    {
+      result /= Binary128{2};
+    }
+  }
+  return result;
+}
+
+Binary128 below_double_resolution_gap() { return binary_power_of_two(-80); }
+
+void expect_gap_is_binary128_only(Binary128 gap)
+{
+  EXPECT_TRUE(Binary128{1} + gap > Binary128{1});
+  EXPECT_EQ(static_cast<double>(Binary128{1} + gap), 1.0);
+}
+
+} // namespace
+
+TEST(MplapackBinary128Test, Uni20NumericLimitsSeesBackendScalar)
+{
+  static_assert(std::is_same_v<uni20::float128, mplapack_binary128_t>);
+  static_assert(std::is_same_v<uni20::complex256, uni20::complex<uni20::float128>>);
+  static_assert(uni20::numeric_limits<Binary128>::is_specialized);
+  EXPECT_GT(uni20::numeric_limits<Binary128>::epsilon(), Binary128{0});
+}
+
+TEST(MplapackBinary128Test, Uni20ScalarConceptsSeeBackendScalar)
+{
+  static_assert(uni20::Real<Binary128>);
+  static_assert(uni20::LapackReal<Binary128>);
+  static_assert(uni20::LapackScalar<Binary128>);
+  static_assert(uni20::LapackRealOrComplex<Binary128>);
+  static_assert(uni20::LapackRealOrComplex<ComplexBinary128>);
+  static_assert(uni20::LapackComplex<ComplexBinary128>);
+  static_assert(uni20::LapackComplexReal<Binary128>);
+  static_assert(uni20::LapackScalar<ComplexBinary128>);
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
+  static_assert(uni20::BlasReal<Binary128>);
+  static_assert(uni20::BlasScalar<Binary128>);
+  static_assert(uni20::BlasComplex<ComplexBinary128>);
+  static_assert(uni20::BlasScalar<ComplexBinary128>);
+#else
+  static_assert(!uni20::BlasReal<Binary128>);
+  static_assert(!uni20::BlasComplex<ComplexBinary128>);
+#endif
+}
+
+TEST(MplapackBinary128Test, Uni20ScalarIoParsesAndFormatsConfiguredFloat128)
+{
+  Binary128 const parsed = uni20::parse_real<Binary128>("1.000000000000000000000000000000001");
+  Binary128 const gap = parsed - Binary128{1};
+
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
+  expect_gap_is_binary128_only(gap);
+#endif
+
+  uni20::scalar_format_options options;
+  options.precision = 36;
+  std::string const formatted = uni20::format_real(parsed, options);
+  EXPECT_TRUE(uni20::parse_real<Binary128>(formatted) == parsed);
+
+  ComplexBinary128 const complex_value{parsed, -gap};
+  std::string const complex_formatted = uni20::format_complex(complex_value, options);
+  EXPECT_NE(complex_formatted.find("-"), std::string::npos);
+  EXPECT_NE(complex_formatted.find("i"), std::string::npos);
+
+  std::string const fmt_formatted = fmt::format("{}", parsed);
+  EXPECT_TRUE(uni20::parse_real<Binary128>(fmt_formatted) == parsed);
+}
+
+TEST(MplapackBinary128Test, Uni20ScalarIoReadsConfiguredFloat128FromStreamToken)
+{
+  std::istringstream input("1.000000000000000000000000000000001");
+  Binary128 parsed = {};
+
+  uni20::read_real(input, parsed);
+
+  EXPECT_TRUE(input);
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
+  expect_gap_is_binary128_only(parsed - Binary128{1});
+#endif
+}
+
+TEST(MplapackBinary128Test, SolvesTinySymmetricEigenproblem)
+{
+  mplapackint constexpr n = 2;
+  Binary128 a[4] = {
+      Binary128{2},
+      Binary128{1},
+      Binary128{1},
+      Binary128{2},
+  };
+  Binary128 w[2] = {};
+  mplapackint info = 0;
+  mplapackint lwork = -1;
+  Binary128 work_query = {};
+
+  Rsyev("V", "U", n, a, n, w, &work_query, lwork, info);
+  ASSERT_EQ(info, 0);
+
+  lwork = static_cast<mplapackint>(work_query);
+  ASSERT_GT(lwork, 0);
+
+  std::vector<Binary128> work(static_cast<std::size_t>(lwork));
+  Rsyev("V", "U", n, a, n, w, work.data(), lwork, info);
+  ASSERT_EQ(info, 0);
+
+  Binary128 const tolerance = static_cast<Binary128>(1.0e-25L);
+  Binary128 const error = std::max(abs_error(w[0], Binary128{1}), abs_error(w[1], Binary128{3}));
+  EXPECT_TRUE(error <= tolerance);
+}
+
+TEST(MplapackBinary128Test, LinksMpblasTransitively)
+{
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
+  mplapackint constexpr n = 2;
+  Binary128 const one = Binary128{1};
+  Binary128 const zero = Binary128{0};
+  Binary128 a[4] = {
+      Binary128{1},
+      Binary128{3},
+      Binary128{2},
+      Binary128{4},
+  };
+  Binary128 b[4] = {
+      Binary128{5},
+      Binary128{7},
+      Binary128{6},
+      Binary128{8},
+  };
+  Binary128 c[4] = {};
+
+  Rgemm("N", "N", n, n, n, one, a, n, b, n, zero, c, n);
+
+  Binary128 const tolerance = static_cast<Binary128>(1.0e-25L);
+  Binary128 const error = std::max({abs_error(c[0], Binary128{19}), abs_error(c[1], Binary128{43}),
+                                    abs_error(c[2], Binary128{22}), abs_error(c[3], Binary128{50})});
+  EXPECT_TRUE(error <= tolerance);
+#else
+  GTEST_SKIP() << "configured MPLAPACK binary128 mode aliases long double, so MPBLAS binary128 wrappers are disabled";
+#endif
+}
+
+TEST(MplapackBinary128Test, Uni20BlasWrappersPreserveBinary128OnlyIncrements)
+{
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE != MPLAPACK_BINARY128_MODE_LDBL)
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const one_plus_delta = Binary128{1} + delta;
+  expect_gap_is_binary128_only(delta);
+
+  Binary128 a[2] = {one_plus_delta, Binary128{-1}};
+  Binary128 b[2] = {Binary128{1}, Binary128{1}};
+  Binary128 c[1] = {};
+  uni20::blas::gemm('N', 'N', 1, 1, 2, Binary128{1}, a, 1, b, 2, Binary128{}, c, 1);
+
+  EXPECT_TRUE(c[0] > Binary128{});
+  EXPECT_TRUE(abs_error(c[0], delta) <= static_cast<Binary128>(1.0e-25L));
+#else
+  GTEST_SKIP() << "configured MPLAPACK binary128 mode aliases long double, so MPBLAS binary128 wrappers are disabled";
+#endif
+}

--- a/tests/krylov/CMakeLists.txt
+++ b/tests/krylov/CMakeLists.txt
@@ -20,3 +20,19 @@ add_test_module(krylov
 
 target_compile_definitions(uni20_krylov_tests PRIVATE
     UNI20_KRYLOV_MATRIX_MARKET_DIR="${CMAKE_CURRENT_SOURCE_DIR}/matrix_market")
+
+if(UNI20_ENABLE_MPLAPACK)
+  add_executable(uni20_krylov_mplapack_binary128_tests
+    test_mplapack_binary128_dense_subspace.cpp
+    test_mplapack_binary128_krylov_solvers.cpp
+  )
+  target_link_libraries(uni20_krylov_mplapack_binary128_tests
+    PRIVATE
+      uni20_krylov
+      GTest::gtest_main
+  )
+  target_compile_definitions(uni20_krylov_mplapack_binary128_tests PRIVATE
+      UNIT_TEST
+      UNI20_KRYLOV_MATRIX_MARKET_DIR="${CMAKE_CURRENT_SOURCE_DIR}/matrix_market")
+  gtest_discover_tests(uni20_krylov_mplapack_binary128_tests)
+endif()

--- a/tests/krylov/krylov_test_types.hpp
+++ b/tests/krylov/krylov_test_types.hpp
@@ -8,16 +8,8 @@
 namespace uni20::krylov::test
 {
 
-#if UNI20_HAS_FLOAT128
-using KrylovRealTestTypes = ::testing::Types<float, double, uni20::float128>;
-using KrylovComplexTestTypes =
-    ::testing::Types<uni20::complex<float>, uni20::complex<double>, uni20::complex<uni20::float128>>;
-using KrylovScalarTestTypes = ::testing::Types<float, double, uni20::float128, uni20::complex<float>,
-                                               uni20::complex<double>, uni20::complex<uni20::float128>>;
-#else
 using KrylovRealTestTypes = ::testing::Types<float, double>;
 using KrylovComplexTestTypes = ::testing::Types<uni20::complex<float>, uni20::complex<double>>;
 using KrylovScalarTestTypes = ::testing::Types<float, double, uni20::complex<float>, uni20::complex<double>>;
-#endif
 
 } // namespace uni20::krylov::test

--- a/tests/krylov/test_mplapack_binary128_dense_subspace.cpp
+++ b/tests/krylov/test_mplapack_binary128_dense_subspace.cpp
@@ -1,0 +1,4077 @@
+#include <mplapack_config.h>
+#include <uni20/krylov/dense_subspace_unused.hpp>
+#include <uni20/krylov/tridiagonal.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <concepts>
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+using Binary128 = mplapack_binary128_t;
+template <typename Scalar> using DenseMatrix = uni20::linalg::backends::cpu::DenseMatrix<Scalar>;
+
+Binary128 abs_error(Binary128 actual, Binary128 expected) { return std::abs(actual - expected); }
+
+Binary128 complex_abs(uni20::complex<Binary128> const& value) { return std::abs(value); }
+
+Binary128 tolerance() { return static_cast<Binary128>(1.0e-30L); }
+
+Binary128 schur_right_eigenvector_residual_max(DenseMatrix<Binary128> const& schur_form,
+                                               uni20::complex<Binary128> eigenvalue,
+                                               DenseMatrix<uni20::complex<Binary128>> const& eigenvectors,
+                                               std::size_t column)
+{
+  Binary128 residual_max{};
+  for (std::size_t row = 0; row < schur_form.rows(); ++row)
+  {
+    uni20::complex<Binary128> applied{};
+    for (std::size_t inner = 0; inner < schur_form.cols(); ++inner)
+    {
+      applied += uni20::complex<Binary128>{schur_form[row, inner], Binary128{}} * eigenvectors[inner, column];
+    }
+    residual_max = std::max(residual_max, complex_abs(applied - eigenvalue * eigenvectors[row, column]));
+  }
+  return residual_max;
+}
+
+Binary128 generalized_schur_right_eigenvector_residual_max(DenseMatrix<Binary128> const& matrix_schur_form,
+                                                           DenseMatrix<Binary128> const& metric_schur_form,
+                                                           uni20::complex<Binary128> eigenvalue,
+                                                           DenseMatrix<uni20::complex<Binary128>> const& eigenvectors,
+                                                           std::size_t column)
+{
+  Binary128 residual_max{};
+  for (std::size_t row = 0; row < matrix_schur_form.rows(); ++row)
+  {
+    uni20::complex<Binary128> matrix_applied{};
+    uni20::complex<Binary128> metric_applied{};
+    for (std::size_t inner = 0; inner < matrix_schur_form.cols(); ++inner)
+    {
+      matrix_applied +=
+          uni20::complex<Binary128>{matrix_schur_form[row, inner], Binary128{}} * eigenvectors[inner, column];
+      metric_applied +=
+          uni20::complex<Binary128>{metric_schur_form[row, inner], Binary128{}} * eigenvectors[inner, column];
+    }
+    residual_max = std::max(residual_max, complex_abs(matrix_applied - eigenvalue * metric_applied));
+  }
+  return residual_max;
+}
+
+std::span<Binary128 const> const_span(std::vector<Binary128> const& values)
+{
+  return std::span<Binary128 const>(values.data(), values.size());
+}
+
+std::span<Binary128> mutable_span(std::vector<Binary128>& values)
+{
+  return std::span<Binary128>(values.data(), values.size());
+}
+
+DenseMatrix<Binary128> multiply_for_test(DenseMatrix<Binary128> const& lhs, DenseMatrix<Binary128> const& rhs)
+{
+  if (lhs.cols() != rhs.rows())
+  {
+    throw std::invalid_argument("test matrix dimensions do not agree");
+  }
+
+  DenseMatrix<Binary128> result(lhs.rows(), rhs.cols());
+  for (std::size_t row = 0; row < lhs.rows(); ++row)
+  {
+    for (std::size_t inner = 0; inner < lhs.cols(); ++inner)
+    {
+      Binary128 const factor = lhs[row, inner];
+      for (std::size_t col = 0; col < rhs.cols(); ++col)
+      {
+        result[row, col] += factor * rhs[inner, col];
+      }
+    }
+  }
+  return result;
+}
+
+DenseMatrix<Binary128> transpose(DenseMatrix<Binary128> const& matrix)
+{
+  DenseMatrix<Binary128> result(matrix.cols(), matrix.rows());
+  for (std::size_t row = 0; row < matrix.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < matrix.cols(); ++col)
+    {
+      result[col, row] = matrix[row, col];
+    }
+  }
+  return result;
+}
+
+DenseMatrix<Binary128> identity_matrix(std::size_t order)
+{
+  DenseMatrix<Binary128> result(order, order);
+  for (std::size_t index = 0; index < order; ++index)
+  {
+    result[index, index] = Binary128{1};
+  }
+  return result;
+}
+
+Binary128 binary_power_of_two(int exponent)
+{
+  Binary128 result{1};
+  if (exponent >= 0)
+  {
+    for (int i = 0; i < exponent; ++i)
+    {
+      result *= Binary128{2};
+    }
+  }
+  else
+  {
+    for (int i = 0; i < -exponent; ++i)
+    {
+      result /= Binary128{2};
+    }
+  }
+  return result;
+}
+
+Binary128 below_double_resolution_gap() { return binary_power_of_two(-80); }
+
+Binary128 below_double_minimum_value() { return binary_power_of_two(-1200); }
+
+void expect_gap_is_binary128_only(Binary128 gap)
+{
+  EXPECT_TRUE(Binary128{1} + gap > Binary128{1});
+  EXPECT_EQ(static_cast<double>(Binary128{1} + gap), 1.0);
+}
+
+void expect_value_underflows_to_double_zero(Binary128 value)
+{
+  EXPECT_GT(value, Binary128{});
+  EXPECT_EQ(static_cast<double>(value), 0.0);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ScalarConceptsAcceptBackendReal)
+{
+  static_assert(uni20::Real<Binary128>);
+  static_assert(uni20::BlasReal<Binary128>);
+  static_assert(uni20::LapackComplex<uni20::complex<Binary128>>);
+  static_assert(uni20::LapackComplexReal<Binary128>);
+  static_assert(uni20::LapackScalar<uni20::complex<Binary128>>);
+  static_assert(std::same_as<uni20::make_complex_t<Binary128>, uni20::complex<Binary128>>);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ComplexNonsymmetricEigensystemResolvesGapBelowDoublePrecision)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+  Complex const first{Binary128{1} + delta, Binary128{1} + delta};
+  Complex const second{Binary128{1} + Binary128{2} * delta, Binary128{1} + Binary128{2} * delta};
+  EXPECT_EQ(static_cast<double>(first.real()), 1.0);
+  EXPECT_EQ(static_cast<double>(first.imag()), 1.0);
+  EXPECT_EQ(static_cast<double>(second.real()), 1.0);
+  EXPECT_EQ(static_cast<double>(second.imag()), 1.0);
+
+  DenseMatrix<Complex> matrix(2, 2);
+  matrix[0, 0] = first;
+  matrix[0, 1] = Complex{delta, -delta};
+  matrix[1, 1] = second;
+
+  auto result = uni20::krylov::complex_nonsymmetric_eigensystem<Binary128>(matrix, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  EXPECT_TRUE(std::min(complex_abs(result.eigenvalues[0] - first), complex_abs(result.eigenvalues[1] - first)) <=
+              Binary128{1000} * tolerance());
+  EXPECT_TRUE(std::min(complex_abs(result.eigenvalues[0] - second), complex_abs(result.eigenvalues[1] - second)) <=
+              Binary128{1000} * tolerance());
+  ASSERT_EQ(result.right_eigenvectors.rows(), 2);
+  ASSERT_EQ(result.right_eigenvectors.cols(), 2);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ComplexSchurResolvesGapBelowDoublePrecision)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+  Complex const first{Binary128{1} + delta, Binary128{1} + delta};
+  Complex const second{Binary128{1} + Binary128{2} * delta, Binary128{1} + Binary128{2} * delta};
+
+  DenseMatrix<Complex> matrix(2, 2);
+  matrix[0, 0] = first;
+  matrix[0, 1] = Complex{delta, -delta};
+  matrix[1, 1] = second;
+
+  auto result = uni20::krylov::complex_schur<Binary128>(matrix, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.schur_form.rows(), 2);
+  ASSERT_EQ(result.schur_form.cols(), 2);
+  ASSERT_EQ(result.schur_vectors.rows(), 2);
+  ASSERT_EQ(result.schur_vectors.cols(), 2);
+  EXPECT_TRUE(std::min(complex_abs(result.eigenvalues[0] - first), complex_abs(result.eigenvalues[1] - first)) <=
+              Binary128{1000} * tolerance());
+  EXPECT_TRUE(std::min(complex_abs(result.eigenvalues[0] - second), complex_abs(result.eigenvalues[1] - second)) <=
+              Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ComplexSchurReordersBinary128SeparatedEntry)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+  Complex const first{Binary128{1} + delta, Binary128{1} + delta};
+  Complex const second{Binary128{1} + Binary128{2} * delta, Binary128{1} + Binary128{2} * delta};
+  Complex const third{Binary128{1} + Binary128{3} * delta, Binary128{1} + Binary128{3} * delta};
+
+  DenseMatrix<Complex> matrix(3, 3);
+  matrix[0, 0] = first;
+  matrix[1, 1] = second;
+  matrix[2, 2] = third;
+
+  auto schur = uni20::krylov::complex_schur<Binary128>(matrix, true);
+  std::size_t third_index = schur.eigenvalues.size();
+  for (std::size_t index = 0; index < schur.eigenvalues.size(); ++index)
+  {
+    if (complex_abs(schur.eigenvalues[index] - third) <= Binary128{1000} * tolerance())
+    {
+      third_index = index;
+      break;
+    }
+  }
+  ASSERT_LT(third_index, schur.eigenvalues.size());
+
+  auto reordered = uni20::krylov::reorder_complex_schur<Binary128>(std::move(schur), {third_index});
+
+  ASSERT_EQ(reordered.eigenvalues.size(), 3);
+  EXPECT_TRUE(complex_abs(reordered.eigenvalues[0] - third) <= Binary128{1000} * tolerance());
+  ASSERT_EQ(reordered.schur_vectors.rows(), 3);
+  ASSERT_EQ(reordered.schur_vectors.cols(), 3);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ComplexHermitianEigensystemResolvesGapBelowDoublePrecision)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Complex> matrix(2, 2);
+  matrix[0, 0] = Complex{Binary128{1}, Binary128{}};
+  matrix[0, 1] = Complex{Binary128{}, offdiagonal};
+  matrix[1, 1] = Complex{Binary128{1} + delta, Binary128{}};
+
+  auto result = uni20::krylov::complex_hermitian_eigensystem<Binary128>(matrix, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Complex const x0 = result.eigenvectors[0, col];
+    Complex const x1 = result.eigenvectors[1, col];
+    Complex const residual0 = x0 + Complex{Binary128{}, offdiagonal} * x1 - lambda * x0;
+    Complex const residual1 = Complex{Binary128{}, -offdiagonal} * x0 + (Binary128{1} + delta) * x1 - lambda * x1;
+    EXPECT_TRUE(std::sqrt(std::norm(residual0) + std::norm(residual1)) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ComplexHermitianDivideAndConquerEigensystemResolvesGapBelowDoublePrecision)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Complex> matrix(2, 2);
+  matrix[0, 0] = Complex{Binary128{1}, Binary128{}};
+  matrix[0, 1] = Complex{Binary128{}, offdiagonal};
+  matrix[1, 1] = Complex{Binary128{1} + delta, Binary128{}};
+
+  auto result = uni20::krylov::complex_hermitian_eigensystem_divide_and_conquer<Binary128>(matrix, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SelectedComplexHermitianEigensystemResolvesGapBelowDoublePrecision)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Complex> matrix(3, 3);
+  matrix[0, 0] = Complex{Binary128{1}, Binary128{}};
+  matrix[1, 1] = Complex{Binary128{1} + delta, Binary128{}};
+  matrix[2, 2] = Complex{Binary128{2}, Binary128{}};
+
+  auto result = uni20::krylov::complex_hermitian_eigensystem_index_range<Binary128>(matrix, 0, 1, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 3);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[1]), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], Binary128{1} + delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ComplexGeneralizedHermitianEigensystemResolvesMetricGapBelowDoublePrecision)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  Binary128 const root_two = std::sqrt(Binary128{2});
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Complex> matrix(2, 2);
+  matrix[0, 0] = Complex{Binary128{1}, Binary128{}};
+  matrix[0, 1] = Complex{Binary128{}, root_two * offdiagonal};
+  matrix[1, 1] = Complex{Binary128{2} * (Binary128{1} + delta), Binary128{}};
+  EXPECT_EQ(static_cast<double>(matrix[1, 1].real()), 2.0);
+
+  DenseMatrix<Complex> metric(2, 2);
+  metric[0, 0] = Complex{Binary128{1}, Binary128{}};
+  metric[1, 1] = Complex{Binary128{2}, Binary128{}};
+
+  auto result = uni20::krylov::complex_generalized_hermitian_eigensystem<Binary128>(matrix, metric, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= Binary128{1000} * tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Complex const x0 = result.eigenvectors[0, col];
+    Complex const x1 = result.eigenvectors[1, col];
+    Complex const residual0 = x0 + Complex{Binary128{}, root_two * offdiagonal} * x1 - lambda * x0;
+    Complex const residual1 = Complex{Binary128{}, -root_two * offdiagonal} * x0 +
+                              Binary128{2} * (Binary128{1} + delta) * x1 - lambda * Binary128{2} * x1;
+    Binary128 const metric_norm = std::norm(x0) + Binary128{2} * std::norm(x1);
+    EXPECT_TRUE(std::sqrt(std::norm(residual0) + std::norm(residual1)) <= Binary128{1000} * tolerance());
+    EXPECT_TRUE(abs_error(metric_norm, Binary128{1}) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest,
+     ComplexGeneralizedHermitianDivideAndConquerEigensystemResolvesMetricGapBelowDoublePrecision)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  Binary128 const root_two = std::sqrt(Binary128{2});
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Complex> matrix(2, 2);
+  matrix[0, 0] = Complex{Binary128{1}, Binary128{}};
+  matrix[0, 1] = Complex{Binary128{}, root_two * offdiagonal};
+  matrix[1, 1] = Complex{Binary128{2} * (Binary128{1} + delta), Binary128{}};
+  EXPECT_EQ(static_cast<double>(matrix[1, 1].real()), 2.0);
+
+  DenseMatrix<Complex> metric(2, 2);
+  metric[0, 0] = Complex{Binary128{1}, Binary128{}};
+  metric[1, 1] = Complex{Binary128{2}, Binary128{}};
+
+  auto result =
+      uni20::krylov::complex_generalized_hermitian_eigensystem_divide_and_conquer<Binary128>(matrix, metric, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest,
+     SelectedComplexGeneralizedHermitianEigensystemResolvesMetricGapBelowDoublePrecision)
+{
+  using Complex = uni20::complex<Binary128>;
+
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Complex> matrix(3, 3);
+  matrix[0, 0] = Complex{Binary128{1}, Binary128{}};
+  matrix[1, 1] = Complex{Binary128{2} * (Binary128{1} + delta), Binary128{}};
+  matrix[2, 2] = Complex{Binary128{6}, Binary128{}};
+  EXPECT_EQ(static_cast<double>(matrix[1, 1].real()), 2.0);
+
+  DenseMatrix<Complex> metric(3, 3);
+  metric[0, 0] = Complex{Binary128{1}, Binary128{}};
+  metric[1, 1] = Complex{Binary128{2}, Binary128{}};
+  metric[2, 2] = Complex{Binary128{3}, Binary128{}};
+
+  auto result =
+      uni20::krylov::complex_generalized_hermitian_eigensystem_index_range<Binary128>(matrix, metric, 0, 1, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 3);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[1]), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], Binary128{1}) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], Binary128{1} + delta) <= Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, MatrixNormsPreserveBinary128OnlyIncrement)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+  Binary128 const one_plus_delta = Binary128{1} + delta;
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = one_plus_delta;
+  matrix[1, 1] = Binary128{1};
+
+  Binary128 const result = uni20::krylov::real_matrix_norm(matrix, uni20::krylov::MatrixNorm::MaxAbs);
+
+  EXPECT_TRUE(abs_error(result, one_plus_delta) <= tolerance());
+  EXPECT_GT(result, Binary128{1});
+  EXPECT_EQ(static_cast<double>(result), 1.0);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, MatrixFrobeniusNormScalesAboveDoubleRange)
+{
+  Binary128 const huge = binary_power_of_two(1200);
+  EXPECT_TRUE(std::isinf(static_cast<double>(huge)));
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = huge;
+  matrix[1, 1] = huge;
+
+  Binary128 const result = uni20::krylov::real_matrix_norm(matrix, uni20::krylov::MatrixNorm::Frobenius);
+  Binary128 const expected_scale = std::sqrt(Binary128{2});
+
+  EXPECT_TRUE(abs_error(result / huge, expected_scale) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(std::isinf(static_cast<double>(result)));
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricMatrixNormPreservesBinary128OnlyColumnSum)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+  Binary128 const expected = Binary128{1} + Binary128{2} * delta;
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[0, 1] = delta;
+  matrix[1, 0] = binary_power_of_two(800);
+  matrix[1, 1] = Binary128{1};
+
+  Binary128 const result = uni20::krylov::real_symmetric_matrix_norm(matrix, uni20::krylov::MatrixNorm::One,
+                                                                     uni20::krylov::MatrixFill::Upper);
+
+  EXPECT_TRUE(abs_error(result, expected) <= Binary128{1000} * tolerance());
+  EXPECT_GT(result, Binary128{1});
+  EXPECT_EQ(static_cast<double>(result), 1.0);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, TriangularMatrixNormPreservesBinary128OnlyDiagonalAndUnitFlag)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+  Binary128 const stored_diagonal_max = Binary128{1} + Binary128{3} * delta;
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1} + Binary128{2} * delta;
+  matrix[0, 1] = delta;
+  matrix[1, 0] = binary_power_of_two(800);
+  matrix[1, 1] = stored_diagonal_max;
+
+  Binary128 const nonunit = uni20::krylov::real_triangular_matrix_norm(matrix, uni20::krylov::MatrixNorm::MaxAbs,
+                                                                       uni20::krylov::MatrixFill::Upper);
+  Binary128 const unit = uni20::krylov::real_triangular_matrix_norm(matrix, uni20::krylov::MatrixNorm::MaxAbs,
+                                                                    uni20::krylov::MatrixFill::Upper, true);
+
+  EXPECT_TRUE(abs_error(nonunit, stored_diagonal_max) <= Binary128{1000} * tolerance());
+  EXPECT_GT(nonunit, Binary128{1});
+  EXPECT_EQ(static_cast<double>(nonunit), 1.0);
+  EXPECT_TRUE(abs_error(unit, Binary128{1}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralBandMatrixNormPreservesValuesBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{2} * tiny;
+  matrix[1, 0] = Binary128{0.5} * tiny;
+  matrix[2, 0] = binary_power_of_two(800);
+  matrix[0, 1] = Binary128{0.25} * tiny;
+  matrix[1, 1] = Binary128{3} * tiny;
+  matrix[2, 1] = Binary128{0.75} * tiny;
+  matrix[1, 2] = Binary128{-0.25} * tiny;
+  matrix[2, 2] = Binary128{4} * tiny;
+
+  auto band = uni20::krylov::real_general_band_from_dense(matrix, 1, 1);
+  Binary128 const result = uni20::krylov::real_general_band_matrix_norm(band, uni20::krylov::MatrixNorm::One);
+
+  expect_value_underflows_to_double_zero(result);
+  EXPECT_TRUE(abs_error(result / tiny, Binary128{4.25}) <= Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralBandSolveAcceptsPivotsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{2} * tiny;
+  matrix[1, 0] = Binary128{0.5} * tiny;
+  matrix[0, 1] = Binary128{0.25} * tiny;
+  matrix[1, 1] = Binary128{3} * tiny;
+  matrix[2, 1] = Binary128{0.75} * tiny;
+  matrix[1, 2] = Binary128{-0.25} * tiny;
+  matrix[2, 2] = Binary128{4} * tiny;
+
+  DenseMatrix<Binary128> expected_solution(3, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{-2};
+  expected_solution[2, 0] = Binary128{3};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    expect_value_underflows_to_double_zero(std::abs(right_hand_side[row, 0]));
+  }
+
+  auto direct_solution = uni20::krylov::real_general_band_solve(
+      uni20::krylov::real_general_band_from_dense(matrix, 1, 1), right_hand_side);
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(direct_solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+
+  auto factorization =
+      uni20::krylov::real_general_band_factorization(uni20::krylov::real_general_band_from_dense(matrix, 1, 1));
+  auto factorized_solution = uni20::krylov::real_general_band_solve(factorization, right_hand_side);
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(factorized_solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralTridiagonalSolveAcceptsPivotingBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{0.25} * tiny;
+  matrix[0, 1] = Binary128{2} * tiny;
+  matrix[1, 0] = Binary128{3} * tiny;
+  matrix[1, 1] = Binary128{4} * tiny;
+  matrix[1, 2] = Binary128{-1} * tiny;
+  matrix[2, 1] = Binary128{0.5} * tiny;
+  matrix[2, 2] = Binary128{5} * tiny;
+
+  auto tridiagonal = uni20::krylov::real_general_tridiagonal_from_dense(matrix);
+  ASSERT_EQ(tridiagonal.diagonal.size(), 3);
+  ASSERT_EQ(tridiagonal.lower_diagonal.size(), 2);
+  ASSERT_EQ(tridiagonal.upper_diagonal.size(), 2);
+  for (Binary128 const value : tridiagonal.diagonal)
+  {
+    expect_value_underflows_to_double_zero(std::abs(value));
+  }
+  for (Binary128 const value : tridiagonal.lower_diagonal)
+  {
+    expect_value_underflows_to_double_zero(std::abs(value));
+  }
+  for (Binary128 const value : tridiagonal.upper_diagonal)
+  {
+    expect_value_underflows_to_double_zero(std::abs(value));
+  }
+
+  DenseMatrix<Binary128> expected_solution(3, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{-2};
+  expected_solution[2, 0] = Binary128{3};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    expect_value_underflows_to_double_zero(std::abs(right_hand_side[row, 0]));
+  }
+
+  auto direct_solution = uni20::krylov::real_general_tridiagonal_solve(tridiagonal, right_hand_side);
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(direct_solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+
+  auto factorization = uni20::krylov::real_general_tridiagonal_factorization(tridiagonal);
+  ASSERT_EQ(factorization.pivot_rows.size(), 3);
+  EXPECT_EQ(factorization.pivot_rows[0], 1);
+  auto factorized_solution = uni20::krylov::real_general_tridiagonal_solve(factorization, right_hand_side);
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(factorized_solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralTridiagonalConditionEstimateStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  auto tridiagonal = uni20::krylov::real_general_tridiagonal_from_dense(matrix);
+  Binary128 const norm = uni20::krylov::real_general_tridiagonal_one_norm(tridiagonal);
+  EXPECT_TRUE(abs_error(norm, Binary128{1}) <= tolerance());
+
+  auto factorization = uni20::krylov::real_general_tridiagonal_factorization(tridiagonal);
+  Binary128 const factorized_rcond =
+      uni20::krylov::real_general_tridiagonal_one_norm_reciprocal_condition_number(factorization, norm);
+  Binary128 const direct_rcond =
+      uni20::krylov::real_general_tridiagonal_one_norm_reciprocal_condition_number(tridiagonal);
+
+  expect_value_underflows_to_double_zero(factorized_rcond);
+  expect_value_underflows_to_double_zero(direct_rcond);
+  EXPECT_TRUE(abs_error(factorized_rcond / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(direct_rcond / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralTridiagonalRefinedSolveUsesMplapackGtrfsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{0.25} * tiny;
+  matrix[0, 1] = Binary128{2} * tiny;
+  matrix[1, 0] = Binary128{3} * tiny;
+  matrix[1, 1] = Binary128{4} * tiny;
+  matrix[1, 2] = Binary128{-1} * tiny;
+  matrix[2, 1] = Binary128{0.5} * tiny;
+  matrix[2, 2] = Binary128{5} * tiny;
+
+  DenseMatrix<Binary128> expected_solution(3, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{-2};
+  expected_solution[2, 0] = Binary128{3};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    expect_value_underflows_to_double_zero(std::abs(right_hand_side[row, 0]));
+  }
+
+  auto result = uni20::krylov::real_general_tridiagonal_refined_solve(
+      uni20::krylov::real_general_tridiagonal_from_dense(matrix), right_hand_side);
+
+  ASSERT_EQ(result.solution.rows(), 3);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_GE(result.forward_error_bounds[0], Binary128{});
+  EXPECT_GE(result.backward_error_bounds[0], Binary128{});
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(result.solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+
+  auto reconstructed = multiply_for_test(matrix, result.solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(reconstructed[row, 0], right_hand_side[row, 0]) <= tiny * Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralTridiagonalExpertSolveUsesMplapackGtsvxBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  DenseMatrix<Binary128> expected_solution(2, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{2};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  EXPECT_TRUE(abs_error(right_hand_side[0, 0], Binary128{1}) <= tolerance());
+  expect_value_underflows_to_double_zero(std::abs(right_hand_side[1, 0]));
+
+  auto result = uni20::krylov::real_general_tridiagonal_expert_linear_solve(
+      uni20::krylov::real_general_tridiagonal_from_dense(matrix), right_hand_side);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  ASSERT_EQ(result.factorization.pivot_rows.size(), 2);
+  EXPECT_TRUE(result.reciprocal_condition_below_machine_precision);
+  expect_value_underflows_to_double_zero(result.reciprocal_condition);
+  EXPECT_TRUE(abs_error(result.reciprocal_condition / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(result.solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralBandReciprocalConditionNumberStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  auto band = uni20::krylov::real_general_band_from_dense(matrix, 0, 0);
+  Binary128 const norm = uni20::krylov::real_general_band_matrix_norm(band, uni20::krylov::MatrixNorm::One);
+  EXPECT_TRUE(abs_error(norm, Binary128{1}) <= tolerance());
+
+  auto factorization = uni20::krylov::real_general_band_factorization(band);
+  Binary128 const factorized_rcond =
+      uni20::krylov::real_general_band_one_norm_reciprocal_condition_number(factorization, norm);
+  Binary128 const direct_rcond = uni20::krylov::real_general_band_one_norm_reciprocal_condition_number(band);
+
+  expect_value_underflows_to_double_zero(factorized_rcond);
+  expect_value_underflows_to_double_zero(direct_rcond);
+  EXPECT_TRUE(abs_error(factorized_rcond / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(direct_rcond / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralBandRefinedSolveUsesMplapackGbrfsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{2} * tiny;
+  matrix[1, 0] = Binary128{0.5} * tiny;
+  matrix[0, 1] = Binary128{0.25} * tiny;
+  matrix[1, 1] = Binary128{3} * tiny;
+  matrix[2, 1] = Binary128{0.75} * tiny;
+  matrix[1, 2] = Binary128{-0.25} * tiny;
+  matrix[2, 2] = Binary128{4} * tiny;
+
+  DenseMatrix<Binary128> expected_solution(3, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{-2};
+  expected_solution[2, 0] = Binary128{3};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    expect_value_underflows_to_double_zero(std::abs(right_hand_side[row, 0]));
+  }
+
+  auto result = uni20::krylov::real_general_band_refined_solve(
+      uni20::krylov::real_general_band_from_dense(matrix, 1, 1), right_hand_side);
+
+  ASSERT_EQ(result.solution.rows(), 3);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_GE(result.forward_error_bounds[0], Binary128{});
+  EXPECT_GE(result.backward_error_bounds[0], Binary128{});
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(result.solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+
+  auto reconstructed = multiply_for_test(matrix, result.solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(reconstructed[row, 0], right_hand_side[row, 0]) <= tiny * Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralBandExpertSolveUsesMplapackGbsvxBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  DenseMatrix<Binary128> right_hand_side(2, 1);
+  right_hand_side[0, 0] = Binary128{1};
+  right_hand_side[1, 0] = tiny;
+  expect_value_underflows_to_double_zero(right_hand_side[1, 0]);
+
+  auto result = uni20::krylov::real_general_band_expert_linear_solve(
+      uni20::krylov::real_general_band_from_dense(matrix, 0, 0), right_hand_side);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.factors.storage.rows(), 1);
+  ASSERT_EQ(result.factors.storage.cols(), 2);
+  ASSERT_EQ(result.pivot_rows.size(), 2);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_EQ(result.equilibration, 'N');
+  EXPECT_TRUE(result.reciprocal_condition_below_machine_precision);
+  expect_value_underflows_to_double_zero(result.reciprocal_condition);
+  EXPECT_TRUE(abs_error(result.reciprocal_condition / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(matrix, result.solution);
+  EXPECT_TRUE(abs_error(reconstructed[0, 0], right_hand_side[0, 0]) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 0], right_hand_side[1, 0]) <= tiny * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralBandEquilibrationPreservesBinary128OnlyScales)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  auto band = uni20::krylov::real_general_band_from_dense(matrix, 0, 0);
+  auto result = uni20::krylov::real_general_band_equilibration(band);
+  auto power_result = uni20::krylov::real_general_band_power_of_two_equilibration(band);
+
+  for (auto const& equilibration : {result, power_result})
+  {
+    ASSERT_EQ(equilibration.row_scale.size(), 2);
+    ASSERT_EQ(equilibration.column_scale.size(), 2);
+    EXPECT_TRUE(equilibration.row_scale[0] > Binary128{});
+    EXPECT_FALSE(std::isfinite(static_cast<double>(equilibration.row_scale[0])));
+    EXPECT_TRUE(abs_error(equilibration.row_scale[0] * tiny, Binary128{1}) <= tolerance());
+    EXPECT_TRUE(abs_error(equilibration.row_scale[1], Binary128{1}) <= tolerance());
+    EXPECT_TRUE(abs_error(equilibration.column_scale[0], Binary128{1}) <= tolerance());
+    EXPECT_TRUE(abs_error(equilibration.column_scale[1], Binary128{1}) <= tolerance());
+    EXPECT_TRUE(abs_error(equilibration.row_condition, tiny) <= tiny * Binary128{1000} * tolerance());
+    EXPECT_TRUE(abs_error(equilibration.column_condition, Binary128{1}) <= tolerance());
+    EXPECT_TRUE(abs_error(equilibration.max_abs, Binary128{1}) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, TridiagonalHelperAcceptsBackendReal)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::symmetric_tridiagonal_matrix<Binary128> matrix(3);
+  matrix.diagonal[0] = Binary128{1};
+  matrix.diagonal[1] = Binary128{1} + delta;
+  matrix.diagonal[2] = Binary128{2};
+  matrix.offdiagonal[0] = delta;
+  matrix.offdiagonal[1] = Binary128{3};
+
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 1.0);
+  EXPECT_TRUE((matrix[1, 1] > Binary128{1}));
+  EXPECT_TRUE(abs_error((matrix.view()[0, 1]), delta) <= tolerance());
+  EXPECT_TRUE(abs_error((matrix.view()[1, 0]), delta) <= tolerance());
+  EXPECT_TRUE(abs_error((matrix.view()[1, 2]), Binary128{3}) <= tolerance());
+  EXPECT_TRUE(abs_error((matrix.view()[0, 2]), Binary128{}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralEquilibrationPreservesBinary128OnlyScales)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  auto result = uni20::krylov::real_equilibration(matrix);
+
+  ASSERT_EQ(result.row_scale.size(), 2);
+  ASSERT_EQ(result.column_scale.size(), 2);
+  EXPECT_TRUE(result.row_scale[0] > Binary128{});
+  EXPECT_FALSE(std::isfinite(static_cast<double>(result.row_scale[0])));
+  EXPECT_TRUE(abs_error(result.row_scale[0] * tiny, Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.row_scale[1], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.column_scale[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.column_scale[1], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.row_condition, tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.column_condition, Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.max_abs, Binary128{1}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RefinedLinearSolvePreservesBinary128OnlyRightHandSide)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1};
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{2};
+
+  auto result = uni20::krylov::real_refined_linear_solve(matrix, rhs);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_EQ(static_cast<double>(result.solution[0, 0]), 0.0);
+  EXPECT_TRUE(abs_error(result.solution[0, 0], tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{2}) <= tolerance());
+  EXPECT_TRUE(result.forward_error_bounds[0] >= Binary128{});
+  EXPECT_TRUE(result.backward_error_bounds[0] >= Binary128{});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealSymmetricEigensystemResolvesDenseGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[0, 1] = offdiagonal;
+  matrix[1, 0] = Binary128{};
+  matrix[1, 1] = Binary128{1} + delta;
+
+  auto result = uni20::krylov::real_symmetric_eigensystem(matrix, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 const x0 = result.eigenvectors[0, col];
+    Binary128 const x1 = result.eigenvectors[1, col];
+    Binary128 const residual0 = x0 + offdiagonal * x1 - lambda * x0;
+    Binary128 const residual1 = offdiagonal * x0 + (Binary128{1} + delta) * x1 - lambda * x1;
+    Binary128 const residual_norm = std::sqrt(residual0 * residual0 + residual1 * residual1);
+    EXPECT_TRUE(residual_norm <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealSymmetricDivideAndConquerEigensystemResolvesDenseGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[0, 1] = offdiagonal;
+  matrix[1, 0] = Binary128{};
+  matrix[1, 1] = Binary128{1} + delta;
+
+  auto result = uni20::krylov::real_symmetric_eigensystem_divide_and_conquer(matrix, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 const x0 = result.eigenvectors[0, col];
+    Binary128 const x1 = result.eigenvectors[1, col];
+    Binary128 const residual0 = x0 + offdiagonal * x1 - lambda * x0;
+    Binary128 const residual1 = offdiagonal * x0 + (Binary128{1} + delta) * x1 - lambda * x1;
+    Binary128 const residual_norm = std::sqrt(residual0 * residual0 + residual1 * residual1);
+    EXPECT_TRUE(residual_norm <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SelectedRealSymmetricEigensystemResolvesDenseGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  matrix[2, 2] = Binary128{2};
+
+  auto result = uni20::krylov::real_symmetric_eigensystem_index_range(matrix, 0, 1, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 3);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[1]), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], Binary128{1} + delta) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 residual_norm{};
+    Binary128 vector_norm{};
+    for (std::size_t row = 0; row < result.eigenvectors.rows(); ++row)
+    {
+      Binary128 const diagonal = row == 0 ? Binary128{1} : (row == 1 ? Binary128{1} + delta : Binary128{2});
+      Binary128 const residual = diagonal * result.eigenvectors[row, col] - lambda * result.eigenvectors[row, col];
+      residual_norm += residual * residual;
+      vector_norm += result.eigenvectors[row, col] * result.eigenvectors[row, col];
+    }
+    EXPECT_TRUE(std::sqrt(residual_norm) <= tolerance());
+    EXPECT_TRUE(abs_error(std::sqrt(vector_norm), Binary128{1}) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealGeneralizedSymmetricEigensystemResolvesMetricGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{2} * (Binary128{1} + delta);
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 2.0);
+
+  DenseMatrix<Binary128> metric(2, 2);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{2};
+
+  auto result = uni20::krylov::real_generalized_symmetric_eigensystem(matrix, metric, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[1]), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(result.eigenvalues[1] - result.eigenvalues[0] > delta / Binary128{2});
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], Binary128{1} + delta) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 const x0 = result.eigenvectors[0, col];
+    Binary128 const x1 = result.eigenvectors[1, col];
+    Binary128 const residual0 = x0 - lambda * x0;
+    Binary128 const residual1 = Binary128{2} * (Binary128{1} + delta) * x1 - lambda * Binary128{2} * x1;
+    Binary128 const residual_norm = std::sqrt(residual0 * residual0 + residual1 * residual1);
+    Binary128 const metric_norm = x0 * x0 + Binary128{2} * x1 * x1;
+    EXPECT_TRUE(residual_norm <= tolerance());
+    EXPECT_TRUE(abs_error(metric_norm, Binary128{1}) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest,
+     RealGeneralizedSymmetricDivideAndConquerEigensystemResolvesMetricGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{2} * (Binary128{1} + delta);
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 2.0);
+
+  DenseMatrix<Binary128> metric(2, 2);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{2};
+
+  auto result = uni20::krylov::real_generalized_symmetric_eigensystem_divide_and_conquer(matrix, metric, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[1]), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(result.eigenvalues[1] - result.eigenvalues[0] > delta / Binary128{2});
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], Binary128{1} + delta) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 const x0 = result.eigenvectors[0, col];
+    Binary128 const x1 = result.eigenvectors[1, col];
+    Binary128 const residual0 = x0 - lambda * x0;
+    Binary128 const residual1 = Binary128{2} * (Binary128{1} + delta) * x1 - lambda * Binary128{2} * x1;
+    Binary128 const residual_norm = std::sqrt(residual0 * residual0 + residual1 * residual1);
+    Binary128 const metric_norm = x0 * x0 + Binary128{2} * x1 * x1;
+    EXPECT_TRUE(residual_norm <= tolerance());
+    EXPECT_TRUE(abs_error(metric_norm, Binary128{1}) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest,
+     SelectedRealGeneralizedSymmetricEigensystemResolvesMetricGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{2} * (Binary128{1} + delta);
+  matrix[2, 2] = Binary128{6};
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 2.0);
+
+  DenseMatrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{2};
+  metric[2, 2] = Binary128{3};
+
+  auto result = uni20::krylov::real_generalized_symmetric_eigensystem_index_range(matrix, metric, 0, 1, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 3);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[1]), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(result.eigenvalues[1] - result.eigenvalues[0] > delta / Binary128{2});
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], Binary128{1} + delta) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 residual_norm{};
+    Binary128 metric_norm{};
+    for (std::size_t row = 0; row < result.eigenvectors.rows(); ++row)
+    {
+      Binary128 const matrix_diagonal =
+          row == 0 ? Binary128{1} : (row == 1 ? Binary128{2} * (Binary128{1} + delta) : Binary128{6});
+      Binary128 const metric_diagonal = Binary128{1} + static_cast<Binary128>(row);
+      Binary128 const value = result.eigenvectors[row, col];
+      Binary128 const residual = matrix_diagonal * value - lambda * metric_diagonal * value;
+      residual_norm += residual * residual;
+      metric_norm += metric_diagonal * value * value;
+    }
+    EXPECT_TRUE(std::sqrt(residual_norm) <= tolerance());
+    EXPECT_TRUE(abs_error(metric_norm, Binary128{1}) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealSingularValueDecompositionResolvesGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[1, 1] = Binary128{1};
+
+  auto result = uni20::krylov::real_singular_value_decomposition(matrix, true);
+
+  ASSERT_EQ(result.singular_values.size(), 2);
+  ASSERT_EQ(result.left_singular_vectors.rows(), 2);
+  ASSERT_EQ(result.left_singular_vectors.cols(), 2);
+  ASSERT_EQ(result.right_singular_vectors_transpose.rows(), 2);
+  ASSERT_EQ(result.right_singular_vectors_transpose.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.singular_values[1]), 1.0);
+  EXPECT_TRUE(result.singular_values[0] > result.singular_values[1]);
+  EXPECT_TRUE(result.singular_values[0] - result.singular_values[1] > delta / Binary128{2});
+  EXPECT_TRUE(abs_error(result.singular_values[0], Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(result.singular_values[1], Binary128{1}) <= tolerance());
+
+  DenseMatrix<Binary128> sigma(2, 2);
+  sigma[0, 0] = result.singular_values[0];
+  sigma[1, 1] = result.singular_values[1];
+  auto reconstructed = multiply_for_test(multiply_for_test(result.left_singular_vectors, sigma),
+                                         result.right_singular_vectors_transpose);
+  for (std::size_t row = 0; row < matrix.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < matrix.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(reconstructed[row, col], matrix[row, col]) <= tolerance());
+    }
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealDivideAndConquerSvdResolvesGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[1, 1] = Binary128{1};
+
+  auto result = uni20::krylov::real_singular_value_decomposition_divide_and_conquer(matrix, true);
+
+  ASSERT_EQ(result.singular_values.size(), 2);
+  ASSERT_EQ(result.left_singular_vectors.rows(), 2);
+  ASSERT_EQ(result.left_singular_vectors.cols(), 2);
+  ASSERT_EQ(result.right_singular_vectors_transpose.rows(), 2);
+  ASSERT_EQ(result.right_singular_vectors_transpose.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.singular_values[1]), 1.0);
+  EXPECT_TRUE(result.singular_values[0] > result.singular_values[1]);
+  EXPECT_TRUE(result.singular_values[0] - result.singular_values[1] > delta / Binary128{2});
+  EXPECT_TRUE(abs_error(result.singular_values[0], Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(result.singular_values[1], Binary128{1}) <= tolerance());
+
+  DenseMatrix<Binary128> sigma(2, 2);
+  sigma[0, 0] = result.singular_values[0];
+  sigma[1, 1] = result.singular_values[1];
+  auto reconstructed = multiply_for_test(multiply_for_test(result.left_singular_vectors, sigma),
+                                         result.right_singular_vectors_transpose);
+  for (std::size_t row = 0; row < matrix.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < matrix.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(reconstructed[row, col], matrix[row, col]) <= tolerance());
+    }
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SelectedRealSvdResolvesGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  matrix[2, 2] = Binary128{2};
+
+  auto values_only = uni20::krylov::real_singular_value_decomposition_index_range(matrix, 1, 2, false);
+  auto result = uni20::krylov::real_singular_value_decomposition_index_range(matrix, 1, 2, true);
+
+  ASSERT_EQ(values_only.singular_values.size(), 2);
+  EXPECT_EQ(static_cast<double>(values_only.singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(values_only.singular_values[1]), 1.0);
+  EXPECT_TRUE(values_only.singular_values[0] > values_only.singular_values[1]);
+  EXPECT_TRUE(abs_error(values_only.singular_values[0] - values_only.singular_values[1], delta) <= tolerance());
+  EXPECT_EQ(values_only.left_singular_vectors.rows(), 0);
+  EXPECT_EQ(values_only.right_singular_vectors_transpose.cols(), 0);
+
+  ASSERT_EQ(result.singular_values.size(), 2);
+  ASSERT_EQ(result.left_singular_vectors.rows(), 3);
+  ASSERT_EQ(result.left_singular_vectors.cols(), 2);
+  ASSERT_EQ(result.right_singular_vectors_transpose.rows(), 2);
+  ASSERT_EQ(result.right_singular_vectors_transpose.cols(), 3);
+  EXPECT_EQ(static_cast<double>(result.singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.singular_values[1]), 1.0);
+  EXPECT_TRUE(result.singular_values[0] > result.singular_values[1]);
+  EXPECT_TRUE(abs_error(result.singular_values[0] - result.singular_values[1], delta) <= tolerance());
+
+  DenseMatrix<Binary128> sigma(2, 2);
+  sigma[0, 0] = result.singular_values[0];
+  sigma[1, 1] = result.singular_values[1];
+  auto selected_contribution = multiply_for_test(multiply_for_test(result.left_singular_vectors, sigma),
+                                                 result.right_singular_vectors_transpose);
+  EXPECT_TRUE(abs_error(selected_contribution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[0, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[0, 2], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[1, 0], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[1, 1], Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[1, 2], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[2, 0], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[2, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[2, 2], Binary128{}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteSolveAcceptsPivotsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = tiny;
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{2} * tiny;
+
+  auto solution = uni20::krylov::real_symmetric_positive_definite_solve(matrix, rhs);
+
+  ASSERT_EQ(solution.rows(), 2);
+  ASSERT_EQ(solution.cols(), 1);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{2}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteFactorizationSolveAcceptsPivotsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = tiny;
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{2} * tiny;
+
+  auto factorization = uni20::krylov::real_symmetric_positive_definite_factorization(matrix);
+  auto solution = uni20::krylov::real_symmetric_positive_definite_solve(factorization, rhs);
+
+  ASSERT_EQ(factorization.factors.rows(), 2);
+  ASSERT_EQ(factorization.factors.cols(), 2);
+  EXPECT_EQ(factorization.triangle, uni20::krylov::MatrixFill::Upper);
+  ASSERT_EQ(solution.rows(), 2);
+  ASSERT_EQ(solution.cols(), 1);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{2}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteBandSolveAcceptsPivotsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{2} * tiny;
+  matrix[0, 1] = Binary128{0.25} * tiny;
+  matrix[1, 0] = matrix[0, 1];
+  matrix[1, 1] = Binary128{3} * tiny;
+  matrix[1, 2] = Binary128{-0.25} * tiny;
+  matrix[2, 1] = matrix[1, 2];
+  matrix[2, 2] = Binary128{4} * tiny;
+
+  DenseMatrix<Binary128> expected_solution(3, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{-2};
+  expected_solution[2, 0] = Binary128{3};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    expect_value_underflows_to_double_zero(std::abs(right_hand_side[row, 0]));
+  }
+
+  auto upper_band =
+      uni20::krylov::real_symmetric_positive_definite_band_from_dense(matrix, 1, uni20::krylov::MatrixFill::Upper);
+  auto direct_solution = uni20::krylov::real_symmetric_positive_definite_band_solve(upper_band, right_hand_side);
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(direct_solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+
+  auto lower_factorization = uni20::krylov::real_symmetric_positive_definite_band_factorization(
+      uni20::krylov::real_symmetric_positive_definite_band_from_dense(matrix, 1, uni20::krylov::MatrixFill::Lower));
+  auto factorized_solution =
+      uni20::krylov::real_symmetric_positive_definite_band_solve(lower_factorization, right_hand_side);
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(factorized_solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteBandConditionEstimateStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  auto band = uni20::krylov::real_symmetric_positive_definite_band_from_dense(matrix, 0);
+  Binary128 const norm = uni20::krylov::real_symmetric_positive_definite_band_one_norm(band);
+  EXPECT_TRUE(abs_error(norm, Binary128{1}) <= tolerance());
+
+  auto factorization = uni20::krylov::real_symmetric_positive_definite_band_factorization(band);
+  Binary128 const factorized_rcond =
+      uni20::krylov::real_symmetric_positive_definite_band_one_norm_reciprocal_condition_number(factorization, norm);
+  Binary128 const direct_rcond =
+      uni20::krylov::real_symmetric_positive_definite_band_one_norm_reciprocal_condition_number(band);
+
+  expect_value_underflows_to_double_zero(factorized_rcond);
+  expect_value_underflows_to_double_zero(direct_rcond);
+  EXPECT_TRUE(abs_error(factorized_rcond / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(direct_rcond / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteBandRefinedSolveUsesMplapackPbrfs)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{2} * tiny;
+  matrix[0, 1] = Binary128{0.25} * tiny;
+  matrix[1, 0] = matrix[0, 1];
+  matrix[1, 1] = Binary128{3} * tiny;
+  matrix[1, 2] = Binary128{-0.25} * tiny;
+  matrix[2, 1] = matrix[1, 2];
+  matrix[2, 2] = Binary128{4} * tiny;
+
+  DenseMatrix<Binary128> expected_solution(3, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{-2};
+  expected_solution[2, 0] = Binary128{3};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    expect_value_underflows_to_double_zero(std::abs(right_hand_side[row, 0]));
+  }
+
+  auto result = uni20::krylov::real_symmetric_positive_definite_band_refined_solve(
+      uni20::krylov::real_symmetric_positive_definite_band_from_dense(matrix, 1), right_hand_side);
+
+  ASSERT_EQ(result.solution.rows(), 3);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_GE(result.forward_error_bounds[0], Binary128{});
+  EXPECT_GE(result.backward_error_bounds[0], Binary128{});
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(result.solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+
+  auto reconstructed = multiply_for_test(matrix, result.solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(reconstructed[row, 0], right_hand_side[row, 0]) <= tiny * Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteBandExpertSolveUsesMplapackPbsvx)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  DenseMatrix<Binary128> expected_solution(2, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{2};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  EXPECT_TRUE(abs_error(right_hand_side[0, 0], Binary128{1}) <= tolerance());
+  expect_value_underflows_to_double_zero(std::abs(right_hand_side[1, 0]));
+
+  auto result = uni20::krylov::real_symmetric_positive_definite_band_expert_linear_solve(
+      uni20::krylov::real_symmetric_positive_definite_band_from_dense(matrix, 0), right_hand_side);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.factorization.factors.storage.rows(), 1);
+  ASSERT_EQ(result.factorization.factors.storage.cols(), 2);
+  ASSERT_EQ(result.scale.size(), 2);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_EQ(result.equilibration, 'N');
+  EXPECT_TRUE(result.reciprocal_condition_below_machine_precision);
+  expect_value_underflows_to_double_zero(result.reciprocal_condition);
+  EXPECT_TRUE(abs_error(result.reciprocal_condition / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(result.solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteTridiagonalSolveAcceptsPivotsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(4, 4);
+  matrix[0, 0] = Binary128{2} * tiny;
+  matrix[0, 1] = Binary128{0.25} * tiny;
+  matrix[1, 0] = matrix[0, 1];
+  matrix[1, 1] = Binary128{3} * tiny;
+  matrix[1, 2] = Binary128{-0.125} * tiny;
+  matrix[2, 1] = matrix[1, 2];
+  matrix[2, 2] = Binary128{4} * tiny;
+  matrix[2, 3] = Binary128{0.5} * tiny;
+  matrix[3, 2] = matrix[2, 3];
+  matrix[3, 3] = Binary128{5} * tiny;
+
+  DenseMatrix<Binary128> expected_solution(4, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{-2};
+  expected_solution[2, 0] = Binary128{3};
+  expected_solution[3, 0] = Binary128{-4};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    expect_value_underflows_to_double_zero(std::abs(right_hand_side[row, 0]));
+  }
+
+  auto tridiagonal = uni20::krylov::real_symmetric_positive_definite_tridiagonal_from_dense(matrix);
+  ASSERT_EQ(tridiagonal.diagonal.size(), 4);
+  ASSERT_EQ(tridiagonal.offdiagonal.size(), 3);
+
+  auto direct_solution =
+      uni20::krylov::real_symmetric_positive_definite_tridiagonal_solve(tridiagonal, right_hand_side);
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(direct_solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+
+  auto factorization = uni20::krylov::real_symmetric_positive_definite_tridiagonal_factorization(tridiagonal);
+  auto factorized_solution =
+      uni20::krylov::real_symmetric_positive_definite_tridiagonal_solve(factorization, right_hand_side);
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(factorized_solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteTridiagonalConditionEstimateStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  auto tridiagonal = uni20::krylov::real_symmetric_positive_definite_tridiagonal_from_dense(matrix);
+  Binary128 const norm = uni20::krylov::real_symmetric_positive_definite_tridiagonal_one_norm(tridiagonal);
+  EXPECT_TRUE(abs_error(norm, Binary128{1}) <= tolerance());
+
+  auto factorization = uni20::krylov::real_symmetric_positive_definite_tridiagonal_factorization(tridiagonal);
+  Binary128 const factorized_rcond =
+      uni20::krylov::real_symmetric_positive_definite_tridiagonal_one_norm_reciprocal_condition_number(factorization,
+                                                                                                       norm);
+  Binary128 const direct_rcond =
+      uni20::krylov::real_symmetric_positive_definite_tridiagonal_one_norm_reciprocal_condition_number(tridiagonal);
+
+  expect_value_underflows_to_double_zero(factorized_rcond);
+  expect_value_underflows_to_double_zero(direct_rcond);
+  EXPECT_TRUE(abs_error(factorized_rcond / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(direct_rcond / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteTridiagonalRefinedSolveUsesMplapackPtrfs)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(4, 4);
+  matrix[0, 0] = Binary128{2} * tiny;
+  matrix[0, 1] = Binary128{0.25} * tiny;
+  matrix[1, 0] = matrix[0, 1];
+  matrix[1, 1] = Binary128{3} * tiny;
+  matrix[1, 2] = Binary128{-0.125} * tiny;
+  matrix[2, 1] = matrix[1, 2];
+  matrix[2, 2] = Binary128{4} * tiny;
+  matrix[2, 3] = Binary128{0.5} * tiny;
+  matrix[3, 2] = matrix[2, 3];
+  matrix[3, 3] = Binary128{5} * tiny;
+
+  DenseMatrix<Binary128> expected_solution(4, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{-2};
+  expected_solution[2, 0] = Binary128{3};
+  expected_solution[3, 0] = Binary128{-4};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    expect_value_underflows_to_double_zero(std::abs(right_hand_side[row, 0]));
+  }
+
+  auto result = uni20::krylov::real_symmetric_positive_definite_tridiagonal_refined_solve(
+      uni20::krylov::real_symmetric_positive_definite_tridiagonal_from_dense(matrix), right_hand_side);
+
+  ASSERT_EQ(result.solution.rows(), 4);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_GE(result.forward_error_bounds[0], Binary128{});
+  EXPECT_GE(result.backward_error_bounds[0], Binary128{});
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(result.solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+
+  auto reconstructed = multiply_for_test(matrix, result.solution);
+  for (std::size_t row = 0; row < right_hand_side.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(reconstructed[row, 0], right_hand_side[row, 0]) <= tiny * Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteTridiagonalExpertSolveUsesMplapackPtsvx)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  DenseMatrix<Binary128> expected_solution(2, 1);
+  expected_solution[0, 0] = Binary128{1};
+  expected_solution[1, 0] = Binary128{2};
+  DenseMatrix<Binary128> right_hand_side = multiply_for_test(matrix, expected_solution);
+  EXPECT_TRUE(abs_error(right_hand_side[0, 0], Binary128{1}) <= tolerance());
+  expect_value_underflows_to_double_zero(std::abs(right_hand_side[1, 0]));
+
+  auto result = uni20::krylov::real_symmetric_positive_definite_tridiagonal_expert_linear_solve(
+      uni20::krylov::real_symmetric_positive_definite_tridiagonal_from_dense(matrix), right_hand_side);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.factorization.factors.diagonal.size(), 2);
+  ASSERT_EQ(result.factorization.factors.offdiagonal.size(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_TRUE(result.reciprocal_condition_below_machine_precision);
+  expect_value_underflows_to_double_zero(result.reciprocal_condition);
+  EXPECT_TRUE(abs_error(result.reciprocal_condition / tiny, Binary128{1}) <= Binary128{1000} * tolerance());
+  for (std::size_t row = 0; row < expected_solution.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(result.solution[row, 0], expected_solution[row, 0]) <= Binary128{1000} * tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, PivotedCholeskyKeepsPivotBelowDoubleMinimumWithBinary128Tolerance)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  Binary128 const tinier = tiny * tiny;
+  expect_value_underflows_to_double_zero(tiny);
+  expect_value_underflows_to_double_zero(tinier);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tinier;
+
+  auto factorization = uni20::krylov::real_pivoted_cholesky_factorization(matrix, tinier / Binary128{2});
+
+  ASSERT_EQ(factorization.factors.rows(), 2);
+  ASSERT_EQ(factorization.factors.cols(), 2);
+  ASSERT_EQ(factorization.pivot_order.size(), 2);
+  EXPECT_EQ(factorization.rank, 2);
+  EXPECT_FALSE(factorization.rank_deficient);
+  EXPECT_EQ(factorization.pivot_order[0], 0);
+  EXPECT_EQ(factorization.pivot_order[1], 1);
+
+  Binary128 const small_factor = factorization.factors[1, 1];
+  EXPECT_GT(small_factor, Binary128{});
+  EXPECT_EQ(static_cast<double>(small_factor), 0.0);
+  EXPECT_TRUE(abs_error(small_factor * small_factor, tinier) <= tinier * Binary128{1000} * tolerance());
+
+  DenseMatrix<Binary128> upper(2, 2);
+  upper[0, 0] = factorization.factors[0, 0];
+  upper[0, 1] = factorization.factors[0, 1];
+  upper[1, 1] = factorization.factors[1, 1];
+  auto reconstructed = multiply_for_test(transpose(upper), upper);
+  EXPECT_TRUE(abs_error(reconstructed[0, 0], matrix[0, 0]) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[0, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 0], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 1], tinier) <= tinier * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteExpertSolveUsesMplapackPosvxBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{2};
+
+  auto result = uni20::krylov::real_symmetric_positive_definite_expert_solve(matrix, rhs);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.factors.rows(), 2);
+  ASSERT_EQ(result.factors.cols(), 2);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  ASSERT_EQ(result.scale.size(), 2);
+  EXPECT_EQ(result.equilibration, 'N');
+  EXPECT_TRUE(result.reciprocal_condition_below_machine_precision);
+  EXPECT_GT(result.reciprocal_condition, Binary128{});
+  EXPECT_EQ(static_cast<double>(result.reciprocal_condition), 0.0);
+  EXPECT_TRUE(abs_error(result.reciprocal_condition, tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{2}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteEquilibrationPreservesBinary128OnlyScales)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  Binary128 const tinier = tiny * tiny;
+  expect_value_underflows_to_double_zero(tinier);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tinier;
+  matrix[1, 1] = Binary128{1};
+
+  auto result = uni20::krylov::real_symmetric_positive_definite_equilibration(matrix);
+
+  ASSERT_EQ(result.scale.size(), 2);
+  EXPECT_TRUE(result.scale[0] > Binary128{});
+  EXPECT_FALSE(std::isfinite(static_cast<double>(result.scale[0])));
+  EXPECT_TRUE(abs_error(result.scale[0] * tiny, Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.scale[1], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.scale_condition, tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.max_abs, Binary128{1}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteRefinedSolvePreservesBinary128OnlyRightHandSide)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1};
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{2};
+
+  auto result = uni20::krylov::real_symmetric_positive_definite_refined_solve(matrix, rhs);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_EQ(static_cast<double>(result.solution[0, 0]), 0.0);
+  EXPECT_TRUE(abs_error(result.solution[0, 0], tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{2}) <= tolerance());
+  EXPECT_TRUE(result.forward_error_bounds[0] >= Binary128{});
+  EXPECT_TRUE(result.backward_error_bounds[0] >= Binary128{});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteConditionEstimateStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  Binary128 const rcond = uni20::krylov::real_symmetric_positive_definite_one_norm_reciprocal_condition_number(matrix);
+
+  EXPECT_GT(rcond, Binary128{});
+  EXPECT_EQ(static_cast<double>(rcond), 0.0);
+  EXPECT_TRUE(abs_error(rcond, tiny) <= tiny * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteFactorizedConditionEstimateStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  auto factorization = uni20::krylov::real_symmetric_positive_definite_factorization(matrix);
+  Binary128 const rcond =
+      uni20::krylov::real_symmetric_positive_definite_one_norm_reciprocal_condition_number(factorization, Binary128{1});
+
+  EXPECT_GT(rcond, Binary128{});
+  EXPECT_EQ(static_cast<double>(rcond), 0.0);
+  EXPECT_TRUE(abs_error(rcond, tiny) <= tiny * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricPositiveDefiniteInverseAcceptsPivotBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  auto inverse = uni20::krylov::real_symmetric_positive_definite_inverse(matrix);
+  auto product = multiply_for_test(matrix, inverse);
+
+  ASSERT_EQ(inverse.rows(), 2);
+  ASSERT_EQ(inverse.cols(), 2);
+  EXPECT_TRUE((inverse[0, 0] > Binary128{1}));
+  EXPECT_FALSE(std::isfinite(static_cast<double>(inverse[0, 0])));
+  EXPECT_TRUE(abs_error(inverse[0, 0] * tiny, Binary128{1}) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(inverse[1, 1], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(product[0, 0], Binary128{1}) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(product[1, 1], Binary128{1}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricIndefiniteSolveAcceptsPivotsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = -tiny;
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = -Binary128{2} * tiny;
+
+  auto solution = uni20::krylov::real_symmetric_indefinite_solve(matrix, rhs);
+
+  ASSERT_EQ(solution.rows(), 2);
+  ASSERT_EQ(solution.cols(), 1);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{2}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricIndefiniteFactorizationSolveAcceptsPivotsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = -tiny;
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = -Binary128{2} * tiny;
+
+  auto factorization = uni20::krylov::real_symmetric_indefinite_factorization(matrix);
+  auto solution = uni20::krylov::real_symmetric_indefinite_solve(factorization, rhs);
+
+  ASSERT_EQ(factorization.factors.rows(), 2);
+  ASSERT_EQ(factorization.factors.cols(), 2);
+  ASSERT_EQ(factorization.pivot_blocks.size(), 2);
+  EXPECT_EQ(factorization.triangle, uni20::krylov::MatrixFill::Upper);
+  ASSERT_EQ(solution.rows(), 2);
+  ASSERT_EQ(solution.cols(), 1);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{2}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricIndefiniteRefinedSolvePreservesBinary128OnlyRightHandSide)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{-1};
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{-2};
+
+  auto result = uni20::krylov::real_symmetric_indefinite_refined_solve(matrix, rhs);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_EQ(static_cast<double>(result.solution[0, 0]), 0.0);
+  EXPECT_TRUE(abs_error(result.solution[0, 0], tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{2}) <= tolerance());
+  EXPECT_TRUE(result.forward_error_bounds[0] >= Binary128{});
+  EXPECT_TRUE(result.backward_error_bounds[0] >= Binary128{});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricIndefiniteInverseAcceptsPivotBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = -tiny;
+
+  auto inverse = uni20::krylov::real_symmetric_indefinite_inverse(matrix);
+  auto product = multiply_for_test(matrix, inverse);
+
+  ASSERT_EQ(inverse.rows(), 2);
+  ASSERT_EQ(inverse.cols(), 2);
+  EXPECT_TRUE((inverse[0, 0] > Binary128{1}));
+  EXPECT_FALSE(std::isfinite(static_cast<double>(inverse[0, 0])));
+  EXPECT_TRUE((inverse[1, 1] < Binary128{-1}));
+  EXPECT_FALSE(std::isfinite(static_cast<double>(inverse[1, 1])));
+  EXPECT_TRUE(abs_error(inverse[0, 0] * tiny, Binary128{1}) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(inverse[1, 1] * tiny, Binary128{-1}) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(product[0, 0], Binary128{1}) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(product[1, 1], Binary128{1}) <= tiny * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricIndefiniteExpertSolveUsesMplapackSysvxBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = -tiny;
+  matrix[1, 1] = Binary128{1};
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = -tiny;
+  rhs[1, 0] = Binary128{2};
+
+  auto result = uni20::krylov::real_symmetric_indefinite_expert_solve(matrix, rhs);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.factors.rows(), 2);
+  ASSERT_EQ(result.factors.cols(), 2);
+  ASSERT_EQ(result.pivot_blocks.size(), 2);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_TRUE(result.reciprocal_condition_below_machine_precision);
+  EXPECT_GT(result.reciprocal_condition, Binary128{});
+  EXPECT_EQ(static_cast<double>(result.reciprocal_condition), 0.0);
+  EXPECT_TRUE(abs_error(result.reciprocal_condition, tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(result.solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{2}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricIndefiniteConditionEstimateStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = -tiny;
+  matrix[1, 1] = Binary128{1};
+
+  Binary128 const rcond = uni20::krylov::real_symmetric_indefinite_one_norm_reciprocal_condition_number(matrix);
+
+  EXPECT_GT(rcond, Binary128{});
+  EXPECT_EQ(static_cast<double>(rcond), 0.0);
+  EXPECT_TRUE(abs_error(rcond, tiny) <= tiny * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricIndefiniteFactorizedConditionEstimateStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = -tiny;
+  matrix[1, 1] = Binary128{1};
+
+  auto factorization = uni20::krylov::real_symmetric_indefinite_factorization(matrix);
+  Binary128 const rcond =
+      uni20::krylov::real_symmetric_indefinite_one_norm_reciprocal_condition_number(factorization, Binary128{1});
+
+  EXPECT_GT(rcond, Binary128{});
+  EXPECT_EQ(static_cast<double>(rcond), 0.0);
+  EXPECT_TRUE(abs_error(rcond, tiny) <= tiny * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, TriangularSolveAcceptsDiagonalBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{2};
+
+  auto solution = uni20::krylov::real_triangular_solve(matrix, rhs);
+
+  ASSERT_EQ(solution.rows(), 2);
+  ASSERT_EQ(solution.cols(), 1);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{2}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, TriangularRefinedSolveAcceptsDiagonalBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{2};
+
+  auto result = uni20::krylov::real_triangular_refined_solve(matrix, rhs);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_TRUE(abs_error(result.solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{2}) <= tolerance());
+  EXPECT_TRUE(result.forward_error_bounds[0] >= Binary128{});
+  EXPECT_TRUE(result.backward_error_bounds[0] >= Binary128{});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, TriangularInverseAcceptsDiagonalBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  auto inverse = uni20::krylov::real_triangular_inverse(matrix);
+  auto product = multiply_for_test(matrix, inverse);
+
+  ASSERT_EQ(inverse.rows(), 2);
+  ASSERT_EQ(inverse.cols(), 2);
+  EXPECT_TRUE((inverse[0, 0] > Binary128{1}));
+  EXPECT_FALSE(std::isfinite(static_cast<double>(inverse[0, 0])));
+  EXPECT_TRUE(abs_error(inverse[0, 0] * tiny, Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(product[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(product[1, 1], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(product[0, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(product[1, 0], Binary128{}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, TriangularConditionEstimateStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  Binary128 const rcond = uni20::krylov::real_triangular_one_norm_reciprocal_condition_number(matrix);
+
+  EXPECT_GT(rcond, Binary128{});
+  EXPECT_EQ(static_cast<double>(rcond), 0.0);
+  EXPECT_TRUE(abs_error(rcond, tiny) <= tiny * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SylvesterSolvePreservesRightHandSideBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> left(1, 1);
+  left[0, 0] = Binary128{1};
+
+  DenseMatrix<Binary128> right(1, 1);
+  right[0, 0] = Binary128{1};
+
+  DenseMatrix<Binary128> rhs(1, 1);
+  rhs[0, 0] = tiny;
+  EXPECT_EQ(static_cast<double>(rhs[0, 0]), 0.0);
+
+  auto result = uni20::krylov::real_sylvester_solve(left, right, rhs);
+
+  ASSERT_EQ(result.solution.rows(), 1);
+  ASSERT_EQ(result.solution.cols(), 1);
+  EXPECT_TRUE(abs_error(result.solution[0, 0], tiny / Binary128{2}) <= tiny * tolerance());
+  EXPECT_TRUE(abs_error(result.scale, Binary128{1}) <= tolerance());
+  EXPECT_FALSE(result.separation_perturbed);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealQrFactorizationPreservesColumnNormBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 1);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[1, 0] = Binary128{-1};
+
+  auto result = uni20::krylov::real_qr_factorization(matrix);
+  Binary128 const expected_norm = std::sqrt((Binary128{1} + delta) * (Binary128{1} + delta) + Binary128{1});
+
+  ASSERT_EQ(result.q.rows(), 2);
+  ASSERT_EQ(result.q.cols(), 1);
+  ASSERT_EQ(result.r.rows(), 1);
+  ASSERT_EQ(result.r.cols(), 1);
+  EXPECT_EQ(static_cast<double>(expected_norm), std::sqrt(2.0));
+  EXPECT_TRUE(std::abs(result.r[0, 0]) > Binary128{1});
+  EXPECT_TRUE(abs_error(std::abs(result.r[0, 0]), expected_norm) <= tolerance());
+
+  Binary128 const q_norm = result.q[0, 0] * result.q[0, 0] + result.q[1, 0] * result.q[1, 0];
+  EXPECT_TRUE(abs_error(q_norm, Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(result.q, result.r);
+  for (std::size_t row = 0; row < matrix.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(reconstructed[row, 0], matrix[row, 0]) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealQrFactorApplicationPreservesColumnNormBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 1);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[1, 0] = Binary128{-1};
+
+  auto compact = uni20::krylov::real_compact_qr_factorization(matrix);
+  auto rotated = uni20::krylov::apply_real_qr_factor(compact, matrix, uni20::krylov::MatrixSide::Left,
+                                                     uni20::krylov::MatrixTranspose::Transpose);
+  Binary128 const expected_norm = std::sqrt((Binary128{1} + delta) * (Binary128{1} + delta) + Binary128{1});
+
+  ASSERT_EQ(compact.rank, 1);
+  ASSERT_EQ(compact.tau.size(), 1);
+  ASSERT_EQ(rotated.rows(), 2);
+  ASSERT_EQ(rotated.cols(), 1);
+  EXPECT_EQ(static_cast<double>(expected_norm), std::sqrt(2.0));
+  EXPECT_TRUE(abs_error(std::abs(rotated[0, 0]), expected_norm) <= tolerance());
+  EXPECT_TRUE(abs_error(rotated[1, 0], Binary128{}) <= tolerance());
+
+  auto identity = identity_matrix(2);
+  auto q = uni20::krylov::apply_real_qr_factor(compact, identity, uni20::krylov::MatrixSide::Left);
+  auto recovered_identity = uni20::krylov::apply_real_qr_factor(compact, q, uni20::krylov::MatrixSide::Left,
+                                                                uni20::krylov::MatrixTranspose::Transpose);
+  for (std::size_t row = 0; row < identity.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < identity.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(recovered_identity[row, col], identity[row, col]) <= tolerance());
+    }
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealLqFactorizationPreservesRowNormBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(1, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[0, 1] = Binary128{-1};
+
+  auto result = uni20::krylov::real_lq_factorization(matrix);
+  Binary128 const expected_norm = std::sqrt((Binary128{1} + delta) * (Binary128{1} + delta) + Binary128{1});
+
+  ASSERT_EQ(result.l.rows(), 1);
+  ASSERT_EQ(result.l.cols(), 1);
+  ASSERT_EQ(result.q.rows(), 1);
+  ASSERT_EQ(result.q.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_norm), std::sqrt(2.0));
+  EXPECT_TRUE(std::abs(result.l[0, 0]) > Binary128{1});
+  EXPECT_TRUE(abs_error(std::abs(result.l[0, 0]), expected_norm) <= tolerance());
+
+  Binary128 const q_norm = result.q[0, 0] * result.q[0, 0] + result.q[0, 1] * result.q[0, 1];
+  EXPECT_TRUE(abs_error(q_norm, Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(result.l, result.q);
+  for (std::size_t col = 0; col < matrix.cols(); ++col)
+  {
+    EXPECT_TRUE(abs_error(reconstructed[0, col], matrix[0, col]) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealLqFactorApplicationPreservesRowNormBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(1, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[0, 1] = Binary128{-1};
+
+  auto compact = uni20::krylov::real_compact_lq_factorization(matrix);
+  auto rotated = uni20::krylov::apply_real_lq_factor(compact, matrix, uni20::krylov::MatrixSide::Right,
+                                                     uni20::krylov::MatrixTranspose::Transpose);
+  Binary128 const expected_norm = std::sqrt((Binary128{1} + delta) * (Binary128{1} + delta) + Binary128{1});
+
+  ASSERT_EQ(compact.rank, 1);
+  ASSERT_EQ(compact.tau.size(), 1);
+  ASSERT_EQ(rotated.rows(), 1);
+  ASSERT_EQ(rotated.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_norm), std::sqrt(2.0));
+  EXPECT_TRUE(abs_error(std::abs(rotated[0, 0]), expected_norm) <= tolerance());
+  EXPECT_TRUE(abs_error(rotated[0, 1], Binary128{}) <= tolerance());
+
+  auto identity = identity_matrix(2);
+  auto q = uni20::krylov::apply_real_lq_factor(compact, identity, uni20::krylov::MatrixSide::Right);
+  auto recovered_identity = uni20::krylov::apply_real_lq_factor(compact, q, uni20::krylov::MatrixSide::Right,
+                                                                uni20::krylov::MatrixTranspose::Transpose);
+  for (std::size_t row = 0; row < identity.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < identity.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(recovered_identity[row, col], identity[row, col]) <= tolerance());
+    }
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealQlFactorizationPreservesColumnNormBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 1);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[1, 0] = Binary128{-1};
+
+  auto result = uni20::krylov::real_ql_factorization(matrix);
+  Binary128 const expected_norm = std::sqrt((Binary128{1} + delta) * (Binary128{1} + delta) + Binary128{1});
+
+  ASSERT_EQ(result.q.rows(), 2);
+  ASSERT_EQ(result.q.cols(), 1);
+  ASSERT_EQ(result.l.rows(), 1);
+  ASSERT_EQ(result.l.cols(), 1);
+  EXPECT_EQ(static_cast<double>(expected_norm), std::sqrt(2.0));
+  EXPECT_TRUE(std::abs(result.l[0, 0]) > Binary128{1});
+  EXPECT_TRUE(abs_error(std::abs(result.l[0, 0]), expected_norm) <= tolerance());
+
+  Binary128 const q_norm = result.q[0, 0] * result.q[0, 0] + result.q[1, 0] * result.q[1, 0];
+  EXPECT_TRUE(abs_error(q_norm, Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(result.q, result.l);
+  for (std::size_t row = 0; row < matrix.rows(); ++row)
+  {
+    EXPECT_TRUE(abs_error(reconstructed[row, 0], matrix[row, 0]) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealQlFactorApplicationPreservesColumnNormBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 1);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[1, 0] = Binary128{-1};
+
+  auto compact = uni20::krylov::real_compact_ql_factorization(matrix);
+  auto rotated = uni20::krylov::apply_real_ql_factor(compact, matrix, uni20::krylov::MatrixSide::Left,
+                                                     uni20::krylov::MatrixTranspose::Transpose);
+  Binary128 const expected_norm = std::sqrt((Binary128{1} + delta) * (Binary128{1} + delta) + Binary128{1});
+
+  ASSERT_EQ(compact.rank, 1);
+  ASSERT_EQ(compact.tau.size(), 1);
+  ASSERT_EQ(rotated.rows(), 2);
+  ASSERT_EQ(rotated.cols(), 1);
+  EXPECT_EQ(static_cast<double>(expected_norm), std::sqrt(2.0));
+  EXPECT_TRUE(abs_error(rotated[0, 0], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(std::abs(rotated[1, 0]), expected_norm) <= tolerance());
+
+  auto identity = identity_matrix(2);
+  auto q = uni20::krylov::apply_real_ql_factor(compact, identity, uni20::krylov::MatrixSide::Left);
+  auto recovered_identity = uni20::krylov::apply_real_ql_factor(compact, q, uni20::krylov::MatrixSide::Left,
+                                                                uni20::krylov::MatrixTranspose::Transpose);
+  for (std::size_t row = 0; row < identity.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < identity.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(recovered_identity[row, col], identity[row, col]) <= tolerance());
+    }
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealRqFactorizationPreservesRowNormBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(1, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[0, 1] = Binary128{-1};
+
+  auto result = uni20::krylov::real_rq_factorization(matrix);
+  Binary128 const expected_norm = std::sqrt((Binary128{1} + delta) * (Binary128{1} + delta) + Binary128{1});
+
+  ASSERT_EQ(result.r.rows(), 1);
+  ASSERT_EQ(result.r.cols(), 1);
+  ASSERT_EQ(result.q.rows(), 1);
+  ASSERT_EQ(result.q.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_norm), std::sqrt(2.0));
+  EXPECT_TRUE(std::abs(result.r[0, 0]) > Binary128{1});
+  EXPECT_TRUE(abs_error(std::abs(result.r[0, 0]), expected_norm) <= tolerance());
+
+  Binary128 const q_norm = result.q[0, 0] * result.q[0, 0] + result.q[0, 1] * result.q[0, 1];
+  EXPECT_TRUE(abs_error(q_norm, Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(result.r, result.q);
+  for (std::size_t col = 0; col < matrix.cols(); ++col)
+  {
+    EXPECT_TRUE(abs_error(reconstructed[0, col], matrix[0, col]) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealRqFactorApplicationPreservesRowNormBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(1, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[0, 1] = Binary128{-1};
+
+  auto compact = uni20::krylov::real_compact_rq_factorization(matrix);
+  auto rotated = uni20::krylov::apply_real_rq_factor(compact, matrix, uni20::krylov::MatrixSide::Right,
+                                                     uni20::krylov::MatrixTranspose::Transpose);
+  Binary128 const expected_norm = std::sqrt((Binary128{1} + delta) * (Binary128{1} + delta) + Binary128{1});
+
+  ASSERT_EQ(compact.rank, 1);
+  ASSERT_EQ(compact.tau.size(), 1);
+  ASSERT_EQ(rotated.rows(), 1);
+  ASSERT_EQ(rotated.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_norm), std::sqrt(2.0));
+  EXPECT_TRUE(abs_error(rotated[0, 0], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(std::abs(rotated[0, 1]), expected_norm) <= tolerance());
+
+  auto identity = identity_matrix(2);
+  auto q = uni20::krylov::apply_real_rq_factor(compact, identity, uni20::krylov::MatrixSide::Right);
+  auto recovered_identity = uni20::krylov::apply_real_rq_factor(compact, q, uni20::krylov::MatrixSide::Right,
+                                                                uni20::krylov::MatrixTranspose::Transpose);
+  for (std::size_t row = 0; row < identity.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < identity.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(recovered_identity[row, col], identity[row, col]) <= tolerance());
+    }
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, BidiagonalReductionReconstructsEntryBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(3, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[1, 0] = Binary128{2};
+  matrix[2, 0] = Binary128{-1};
+  matrix[0, 1] = Binary128{3};
+  matrix[1, 1] = Binary128{-2};
+  matrix[2, 1] = Binary128{5};
+
+  auto reduction = uni20::krylov::real_bidiagonal_reduction(matrix);
+  auto q = uni20::krylov::real_bidiagonal_left_orthogonal_factor(reduction);
+  auto pt = uni20::krylov::real_bidiagonal_right_orthogonal_factor_transpose(reduction);
+  auto reconstructed = multiply_for_test(multiply_for_test(q, reduction.bidiagonal), pt);
+
+  ASSERT_EQ(reduction.bidiagonal.rows(), 3);
+  ASSERT_EQ(reduction.bidiagonal.cols(), 2);
+  ASSERT_EQ(reduction.diagonal.size(), 2);
+  ASSERT_EQ(reduction.offdiagonal.size(), 1);
+  EXPECT_TRUE(reduction.upper);
+  EXPECT_EQ(static_cast<double>(reconstructed[0, 0]), 1.0);
+  EXPECT_TRUE((reconstructed[0, 0] > Binary128{1}));
+  for (std::size_t row = 0; row < matrix.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < matrix.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(reconstructed[row, col], matrix[row, col]) <= Binary128{1000} * tolerance());
+    }
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, BidiagonalFactorApplicationPreservesEntryBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(3, 2);
+  matrix[0, 0] = Binary128{1} + delta;
+  matrix[1, 0] = Binary128{2};
+  matrix[2, 0] = Binary128{-1};
+  matrix[0, 1] = Binary128{3};
+  matrix[1, 1] = Binary128{-2};
+  matrix[2, 1] = Binary128{5};
+
+  auto reduction = uni20::krylov::real_bidiagonal_reduction(matrix);
+  auto q = uni20::krylov::apply_real_bidiagonal_left_factor(reduction, identity_matrix(3));
+  auto pt = uni20::krylov::apply_real_bidiagonal_right_factor(
+      reduction, identity_matrix(2), uni20::krylov::MatrixSide::Left, uni20::krylov::MatrixTranspose::Transpose);
+  auto reconstructed = multiply_for_test(multiply_for_test(q, reduction.bidiagonal), pt);
+  auto recovered_q = uni20::krylov::apply_real_bidiagonal_left_factor(reduction, q, uni20::krylov::MatrixSide::Left,
+                                                                      uni20::krylov::MatrixTranspose::Transpose);
+  auto recovered_p = uni20::krylov::apply_real_bidiagonal_right_factor(reduction, pt, uni20::krylov::MatrixSide::Left);
+  auto identity_q = identity_matrix(3);
+  auto identity_p = identity_matrix(2);
+
+  EXPECT_EQ(static_cast<double>(reconstructed[0, 0]), 1.0);
+  EXPECT_TRUE((reconstructed[0, 0] > Binary128{1}));
+  for (std::size_t row = 0; row < matrix.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < matrix.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(reconstructed[row, col], matrix[row, col]) <= Binary128{1000} * tolerance());
+    }
+  }
+  for (std::size_t row = 0; row < recovered_q.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < recovered_q.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(recovered_q[row, col], identity_q[row, col]) <= Binary128{1000} * tolerance());
+    }
+  }
+  for (std::size_t row = 0; row < recovered_p.rows(); ++row)
+  {
+    for (std::size_t col = 0; col < recovered_p.cols(); ++col)
+    {
+      EXPECT_TRUE(abs_error(recovered_p[row, col], identity_p[row, col]) <= Binary128{1000} * tolerance());
+    }
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, BidiagonalSingularValuesResolveGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  std::vector<Binary128> diagonal{Binary128{1}, Binary128{1} + delta};
+  std::vector<Binary128> offdiagonal{Binary128{}};
+
+  auto singular_values = uni20::krylov::real_bidiagonal_singular_values(diagonal, offdiagonal);
+
+  ASSERT_EQ(singular_values.size(), 2);
+  EXPECT_EQ(static_cast<double>(singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(singular_values[1]), 1.0);
+  EXPECT_TRUE(singular_values[0] > singular_values[1]);
+  EXPECT_TRUE(abs_error(singular_values[0] - singular_values[1], delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, BidiagonalDivideAndConquerSvdResolvesGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  std::vector<Binary128> diagonal{Binary128{1}, Binary128{1} + delta};
+  std::vector<Binary128> offdiagonal{Binary128{}};
+
+  auto values_only = uni20::krylov::real_bidiagonal_svd(diagonal, offdiagonal, false);
+  auto result = uni20::krylov::real_bidiagonal_svd(diagonal, offdiagonal, true);
+
+  ASSERT_EQ(values_only.singular_values.size(), 2);
+  EXPECT_EQ(static_cast<double>(values_only.singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(values_only.singular_values[1]), 1.0);
+  EXPECT_TRUE(values_only.singular_values[0] > values_only.singular_values[1]);
+  EXPECT_TRUE(abs_error(values_only.singular_values[0] - values_only.singular_values[1], delta) <= tolerance());
+  EXPECT_EQ(values_only.u.rows(), 0);
+  EXPECT_EQ(values_only.vt.cols(), 0);
+
+  ASSERT_EQ(result.singular_values.size(), 2);
+  ASSERT_EQ(result.u.rows(), 2);
+  ASSERT_EQ(result.u.cols(), 2);
+  ASSERT_EQ(result.vt.rows(), 2);
+  ASSERT_EQ(result.vt.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result.singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.singular_values[1]), 1.0);
+  EXPECT_TRUE(result.singular_values[0] > result.singular_values[1]);
+  EXPECT_TRUE(abs_error(result.singular_values[0] - result.singular_values[1], delta) <= tolerance());
+
+  DenseMatrix<Binary128> sigma(2, 2);
+  sigma[0, 0] = result.singular_values[0];
+  sigma[1, 1] = result.singular_values[1];
+  auto reconstructed = multiply_for_test(multiply_for_test(result.u, sigma), result.vt);
+  EXPECT_TRUE(abs_error(reconstructed[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[0, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 0], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 1], Binary128{1} + delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SelectedBidiagonalSvdResolvesGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  std::vector<Binary128> diagonal{Binary128{1}, Binary128{1} + delta, Binary128{2}};
+  std::vector<Binary128> offdiagonal{Binary128{}, Binary128{}};
+
+  auto values_only = uni20::krylov::real_bidiagonal_svd_index_range(diagonal, offdiagonal, 1, 2, false);
+  auto result = uni20::krylov::real_bidiagonal_svd_index_range(diagonal, offdiagonal, 1, 2, true);
+
+  ASSERT_EQ(values_only.singular_values.size(), 2);
+  EXPECT_EQ(static_cast<double>(values_only.singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(values_only.singular_values[1]), 1.0);
+  EXPECT_TRUE(values_only.singular_values[0] > values_only.singular_values[1]);
+  EXPECT_TRUE(abs_error(values_only.singular_values[0] - values_only.singular_values[1], delta) <= tolerance());
+  EXPECT_EQ(values_only.u.rows(), 0);
+  EXPECT_EQ(values_only.vt.cols(), 0);
+
+  ASSERT_EQ(result.singular_values.size(), 2);
+  ASSERT_EQ(result.u.rows(), 3);
+  ASSERT_EQ(result.u.cols(), 2);
+  ASSERT_EQ(result.vt.rows(), 2);
+  ASSERT_EQ(result.vt.cols(), 3);
+  EXPECT_EQ(static_cast<double>(result.singular_values[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.singular_values[1]), 1.0);
+  EXPECT_TRUE(result.singular_values[0] > result.singular_values[1]);
+  EXPECT_TRUE(abs_error(result.singular_values[0] - result.singular_values[1], delta) <= tolerance());
+
+  DenseMatrix<Binary128> sigma(2, 2);
+  sigma[0, 0] = result.singular_values[0];
+  sigma[1, 1] = result.singular_values[1];
+  auto selected_contribution = multiply_for_test(multiply_for_test(result.u, sigma), result.vt);
+  EXPECT_TRUE(abs_error(selected_contribution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[0, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[0, 2], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[1, 0], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[1, 1], Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[1, 2], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[2, 0], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[2, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(selected_contribution[2, 2], Binary128{}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, HessenbergReductionPreservesBinary128OnlyEntry)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{3};
+  matrix[1, 0] = Binary128{2};
+  matrix[2, 0] = Binary128{1} / Binary128{5};
+  matrix[0, 1] = Binary128{-1};
+  matrix[1, 1] = Binary128{1} + delta;
+  matrix[2, 1] = Binary128{4};
+  matrix[0, 2] = Binary128{2};
+  matrix[1, 2] = Binary128{-3};
+  matrix[2, 2] = Binary128{5};
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 1.0);
+
+  auto reduction = uni20::krylov::real_hessenberg_reduction(matrix);
+  auto q = uni20::krylov::real_hessenberg_orthogonal_factor(reduction);
+  auto reconstructed = multiply_for_test(multiply_for_test(q, reduction.hessenberg), transpose(q));
+  auto orthogonality = multiply_for_test(transpose(q), q);
+  auto identity = identity_matrix(3);
+
+  ASSERT_EQ(reduction.hessenberg.rows(), 3);
+  ASSERT_EQ(reduction.hessenberg.cols(), 3);
+  ASSERT_EQ(reduction.reflectors.rows(), 3);
+  ASSERT_EQ(reduction.reflectors.cols(), 3);
+  ASSERT_EQ(reduction.tau.size(), 2);
+  EXPECT_TRUE(abs_error(reduction.hessenberg[2, 0], Binary128{}) <= tolerance());
+  for (std::size_t row = 0; row < 3; ++row)
+  {
+    for (std::size_t col = 0; col < 3; ++col)
+    {
+      EXPECT_TRUE(abs_error(orthogonality[row, col], identity[row, col]) <= tolerance());
+      EXPECT_TRUE(abs_error(reconstructed[row, col], matrix[row, col]) <= tolerance());
+    }
+  }
+  EXPECT_EQ(static_cast<double>(reconstructed[1, 1]), 1.0);
+  EXPECT_TRUE((reconstructed[1, 1] > Binary128{1}));
+  EXPECT_TRUE(abs_error(reconstructed[1, 1], Binary128{1} + delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, HessenbergOrthogonalFactorApplicationPreservesTinyTarget)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{3};
+  matrix[1, 0] = Binary128{2};
+  matrix[2, 0] = Binary128{1} / Binary128{5};
+  matrix[0, 1] = Binary128{-1};
+  matrix[1, 1] = Binary128{1};
+  matrix[2, 1] = Binary128{4};
+  matrix[0, 2] = Binary128{2};
+  matrix[1, 2] = Binary128{-3};
+  matrix[2, 2] = Binary128{5};
+
+  auto reduction = uni20::krylov::real_hessenberg_reduction(matrix);
+  auto q = uni20::krylov::real_hessenberg_orthogonal_factor(reduction);
+
+  DenseMatrix<Binary128> target(3, 1);
+  target[1, 0] = tiny;
+  target[2, 0] = Binary128{2} * tiny;
+
+  auto applied = uni20::krylov::apply_real_hessenberg_orthogonal_factor(reduction, target);
+  auto expected = multiply_for_test(q, target);
+  auto recovered = uni20::krylov::apply_real_hessenberg_orthogonal_factor(
+      reduction, applied, uni20::krylov::MatrixSide::Left, uni20::krylov::MatrixTranspose::Transpose);
+
+  ASSERT_EQ(applied.rows(), 3);
+  ASSERT_EQ(applied.cols(), 1);
+  for (std::size_t row = 0; row < target.rows(); ++row)
+  {
+    Binary128 const scale = std::max(tiny, std::abs(expected[row, 0]));
+    EXPECT_EQ(static_cast<double>(expected[row, 0]), 0.0);
+    EXPECT_TRUE(abs_error(applied[row, 0], expected[row, 0]) <= scale * Binary128{1000} * tolerance());
+    EXPECT_TRUE(abs_error(recovered[row, 0], target[row, 0]) <= tiny * Binary128{1000} * tolerance());
+  }
+  EXPECT_GT(std::abs(applied[1, 0]) + std::abs(applied[2, 0]), Binary128{});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricTridiagonalReductionPreservesTinyOffdiagonal)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 0] = tiny;
+  matrix[0, 1] = tiny;
+  matrix[1, 1] = Binary128{2};
+  matrix[2, 1] = Binary128{1} / Binary128{3};
+  matrix[1, 2] = Binary128{1} / Binary128{3};
+  matrix[2, 2] = Binary128{3};
+
+  auto reduction = uni20::krylov::real_symmetric_tridiagonal_reduction(matrix, uni20::krylov::MatrixFill::Lower);
+
+  ASSERT_EQ(reduction.diagonal.size(), 3);
+  ASSERT_EQ(reduction.offdiagonal.size(), 2);
+  EXPECT_TRUE(abs_error(reduction.diagonal[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(reduction.diagonal[1], Binary128{2}) <= tolerance());
+  EXPECT_TRUE(abs_error(reduction.diagonal[2], Binary128{3}) <= tolerance());
+  EXPECT_TRUE(abs_error(reduction.offdiagonal[0], tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(reduction.offdiagonal[1], Binary128{1} / Binary128{3}) <= tolerance());
+  EXPECT_EQ(static_cast<double>(reduction.offdiagonal[0]), 0.0);
+  EXPECT_TRUE(abs_error(reduction.tridiagonal[1, 0], tiny) <= tiny * Binary128{1000} * tolerance());
+  EXPECT_TRUE(abs_error(reduction.tridiagonal[0, 1], tiny) <= tiny * Binary128{1000} * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricTridiagonalOrthogonalFactorApplicationPreservesTinyTarget)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{3};
+  matrix[1, 0] = Binary128{-1};
+  matrix[2, 0] = Binary128{2};
+  matrix[0, 1] = Binary128{-1};
+  matrix[1, 1] = Binary128{1};
+  matrix[2, 1] = Binary128{4};
+  matrix[0, 2] = Binary128{2};
+  matrix[1, 2] = Binary128{4};
+  matrix[2, 2] = Binary128{5};
+
+  auto reduction = uni20::krylov::real_symmetric_tridiagonal_reduction(matrix);
+  auto q = uni20::krylov::real_symmetric_tridiagonal_orthogonal_factor(reduction);
+
+  DenseMatrix<Binary128> target(3, 1);
+  target[1, 0] = tiny;
+  target[2, 0] = Binary128{2} * tiny;
+
+  auto applied = uni20::krylov::apply_real_symmetric_tridiagonal_orthogonal_factor(reduction, target);
+  auto expected = multiply_for_test(q, target);
+  auto recovered = uni20::krylov::apply_real_symmetric_tridiagonal_orthogonal_factor(
+      reduction, applied, uni20::krylov::MatrixSide::Left, uni20::krylov::MatrixTranspose::Transpose);
+
+  ASSERT_EQ(applied.rows(), 3);
+  ASSERT_EQ(applied.cols(), 1);
+  for (std::size_t row = 0; row < target.rows(); ++row)
+  {
+    Binary128 const scale = std::max(tiny, std::abs(expected[row, 0]));
+    EXPECT_EQ(static_cast<double>(expected[row, 0]), 0.0);
+    EXPECT_TRUE(abs_error(applied[row, 0], expected[row, 0]) <= scale * Binary128{1000} * tolerance());
+    EXPECT_TRUE(abs_error(recovered[row, 0], target[row, 0]) <= tiny * Binary128{1000} * tolerance());
+  }
+  EXPECT_GT(std::abs(applied[1, 0]) + std::abs(applied[2, 0]), Binary128{});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealPivotedQrFactorizationPreservesColumnBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = tiny;
+  matrix[1, 1] = Binary128{1};
+
+  auto result = uni20::krylov::real_pivoted_qr_factorization(matrix);
+
+  ASSERT_EQ(result.q.rows(), 2);
+  ASSERT_EQ(result.q.cols(), 2);
+  ASSERT_EQ(result.r.rows(), 2);
+  ASSERT_EQ(result.r.cols(), 2);
+  ASSERT_EQ(result.pivot_columns.size(), 2);
+  EXPECT_EQ(result.pivot_columns[0], 1);
+  EXPECT_EQ(result.pivot_columns[1], 0);
+
+  auto pivoted_reconstructed = multiply_for_test(result.q, result.r);
+  for (std::size_t col = 0; col < matrix.cols(); ++col)
+  {
+    std::size_t const original_col = result.pivot_columns[col];
+    for (std::size_t row = 0; row < matrix.rows(); ++row)
+    {
+      Binary128 const expected = matrix[row, original_col];
+      Binary128 const scale = std::max(tiny, std::abs(expected));
+      EXPECT_TRUE(abs_error(pivoted_reconstructed[row, col], expected) <= scale * tolerance());
+    }
+  }
+  EXPECT_TRUE(abs_error(pivoted_reconstructed[0, 1], tiny) <= tiny * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealLeastSquaresPreservesSolutionBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const one_plus_delta = Binary128{1} + delta;
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> coefficients(2, 1);
+  coefficients[0, 0] = Binary128{1};
+  coefficients[1, 0] = Binary128{1};
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = one_plus_delta;
+  rhs[1, 0] = one_plus_delta;
+  EXPECT_EQ(static_cast<double>(rhs[0, 0]), 1.0);
+  EXPECT_EQ(static_cast<double>(rhs[1, 0]), 1.0);
+
+  auto solution = uni20::krylov::real_least_squares(coefficients, rhs);
+
+  ASSERT_EQ(solution.rows(), 1);
+  ASSERT_EQ(solution.cols(), 1);
+  EXPECT_EQ(static_cast<double>(solution[0, 0]), 1.0);
+  EXPECT_TRUE((solution[0, 0] > Binary128{1}));
+  EXPECT_TRUE(abs_error(solution[0, 0], one_plus_delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SvdLeastSquaresKeepsTinyBinary128SingularValue)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> coefficients(2, 2);
+  coefficients[0, 0] = Binary128{1};
+  coefficients[1, 1] = tiny;
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = Binary128{1};
+  rhs[1, 0] = tiny;
+
+  Binary128 const rcond = tiny / Binary128{4};
+  EXPECT_EQ(static_cast<double>(rcond), 0.0);
+
+  auto result = uni20::krylov::real_svd_least_squares(coefficients, rhs, rcond);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.singular_values.size(), 2);
+  EXPECT_EQ(result.rank, 2);
+  EXPECT_TRUE(abs_error(result.singular_values[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.singular_values[1], tiny) <= tiny * tolerance());
+  EXPECT_EQ(static_cast<double>(result.singular_values[1]), 0.0);
+  EXPECT_TRUE(abs_error(result.solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(coefficients, result.solution);
+  EXPECT_TRUE(abs_error(reconstructed[0, 0], rhs[0, 0]) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 0], rhs[1, 0]) <= tiny * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, DivideAndConquerSvdLeastSquaresKeepsTinyBinary128SingularValue)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> coefficients(2, 2);
+  coefficients[0, 0] = Binary128{1};
+  coefficients[1, 1] = tiny;
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = Binary128{1};
+  rhs[1, 0] = tiny;
+
+  Binary128 const rcond = tiny / Binary128{4};
+  EXPECT_EQ(static_cast<double>(rcond), 0.0);
+
+  auto result = uni20::krylov::real_divide_and_conquer_svd_least_squares(coefficients, rhs, rcond);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.singular_values.size(), 2);
+  EXPECT_EQ(result.rank, 2);
+  EXPECT_TRUE(abs_error(result.singular_values[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.singular_values[1], tiny) <= tiny * tolerance());
+  EXPECT_EQ(static_cast<double>(result.singular_values[1]), 0.0);
+  EXPECT_TRUE(abs_error(result.solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(coefficients, result.solution);
+  EXPECT_TRUE(abs_error(reconstructed[0, 0], rhs[0, 0]) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 0], rhs[1, 0]) <= tiny * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RankRevealingLeastSquaresKeepsTinyBinary128Column)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> coefficients(2, 2);
+  coefficients[0, 0] = Binary128{1};
+  coefficients[1, 1] = tiny;
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = Binary128{1};
+  rhs[1, 0] = tiny;
+
+  Binary128 const rcond = tiny / Binary128{4};
+  EXPECT_EQ(static_cast<double>(rcond), 0.0);
+
+  auto result = uni20::krylov::real_rank_revealing_least_squares(coefficients, rhs, rcond);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.pivot_columns.size(), 2);
+  EXPECT_EQ(result.rank, 2);
+  EXPECT_TRUE(abs_error(result.solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(coefficients, result.solution);
+  EXPECT_TRUE(abs_error(reconstructed[0, 0], rhs[0, 0]) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 0], rhs[1, 0]) <= tiny * tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealDenseSolveUsesMplapackGesvBelowDoubleResolution)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[0, 1] = Binary128{1};
+  matrix[1, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 1.0);
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = Binary128{2};
+  rhs[1, 0] = Binary128{2} + delta;
+
+  auto solution = uni20::krylov::real_dense_solve_linear_system(matrix, rhs);
+
+  ASSERT_EQ(solution.rows(), 2);
+  ASSERT_EQ(solution.cols(), 1);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{1}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ExpertDenseSolveUsesMplapackGesvxBelowDoubleResolution)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[0, 1] = Binary128{1};
+  matrix[1, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 1.0);
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = Binary128{2};
+  rhs[1, 0] = Binary128{2} + delta;
+
+  auto result = uni20::krylov::real_expert_linear_solve(matrix, rhs);
+
+  ASSERT_EQ(result.solution.rows(), 2);
+  ASSERT_EQ(result.solution.cols(), 1);
+  ASSERT_EQ(result.factors.rows(), 2);
+  ASSERT_EQ(result.factors.cols(), 2);
+  ASSERT_EQ(result.pivot_rows.size(), 2);
+  ASSERT_EQ(result.forward_error_bounds.size(), 1);
+  ASSERT_EQ(result.backward_error_bounds.size(), 1);
+  EXPECT_TRUE(result.equilibration == 'N' || result.equilibration == 'R' || result.equilibration == 'C' ||
+              result.equilibration == 'B');
+  EXPECT_TRUE(result.reciprocal_condition > Binary128{});
+  EXPECT_TRUE(abs_error(result.solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.solution[1, 0], Binary128{1}) <= tolerance());
+
+  auto reconstructed = multiply_for_test(matrix, result.solution);
+  EXPECT_TRUE(abs_error(reconstructed[0, 0], rhs[0, 0]) <= tolerance());
+  EXPECT_TRUE(abs_error(reconstructed[1, 0], rhs[1, 0]) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealLuSolveUsesMplapackGetrsBelowDoubleResolution)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[0, 1] = Binary128{1};
+  matrix[1, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 1.0);
+
+  DenseMatrix<Binary128> rhs(2, 2);
+  rhs[0, 0] = Binary128{2};
+  rhs[1, 0] = Binary128{2} + delta;
+  rhs[0, 1] = Binary128{1};
+  rhs[1, 1] = Binary128{1} + delta;
+
+  auto factorization = uni20::krylov::real_lu_factorization(matrix);
+  auto solution = uni20::krylov::real_lu_solve(factorization, rhs);
+
+  ASSERT_EQ(factorization.factors.rows(), 2);
+  ASSERT_EQ(factorization.factors.cols(), 2);
+  ASSERT_EQ(factorization.pivot_rows.size(), 2);
+  ASSERT_EQ(solution.rows(), 2);
+  ASSERT_EQ(solution.cols(), 2);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[0, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 1], Binary128{1}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealReciprocalConditionNumberStaysInBinary128)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = tiny;
+
+  auto factorization = uni20::krylov::real_lu_factorization(matrix);
+  Binary128 const from_factorization =
+      uni20::krylov::real_lu_one_norm_reciprocal_condition_number(factorization, Binary128{1});
+  Binary128 const direct = uni20::krylov::real_one_norm_reciprocal_condition_number(matrix);
+
+  EXPECT_TRUE(abs_error(from_factorization, tiny) <= tiny * tolerance());
+  EXPECT_TRUE(abs_error(direct, tiny) <= tiny * tolerance());
+  EXPECT_EQ(static_cast<double>(from_factorization), 0.0);
+  EXPECT_EQ(static_cast<double>(direct), 0.0);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealDenseInverseAcceptsPivotGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 0] = Binary128{1};
+  matrix[0, 1] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 1.0);
+
+  auto inverse = uni20::krylov::real_dense_inverse(matrix);
+
+  ASSERT_EQ(inverse.rows(), 2);
+  ASSERT_EQ(inverse.cols(), 2);
+  EXPECT_TRUE(abs_error(inverse[0, 0] * delta, Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(inverse[1, 0] * delta, Binary128{-1}) <= tolerance());
+  EXPECT_TRUE(abs_error(inverse[0, 1] * delta, Binary128{-1}) <= tolerance());
+  EXPECT_TRUE(abs_error(inverse[1, 1] * delta, Binary128{1}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, LocalDenseOpsPreserveBinary128OnlyIncrements)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const one_plus_delta = Binary128{1} + delta;
+  expect_gap_is_binary128_only(delta);
+
+  std::vector<Binary128> cancellation_x{one_plus_delta, Binary128{-1}};
+  std::vector<Binary128> cancellation_y{Binary128{1}, Binary128{1}};
+  Binary128 const dot_result = uni20::krylov::dot(const_span(cancellation_x), const_span(cancellation_y));
+  EXPECT_TRUE(abs_error(dot_result, delta) <= tolerance());
+
+  std::vector<Binary128> norm_vector{one_plus_delta};
+  Binary128 const norm_result = uni20::krylov::nrm2(const_span(norm_vector));
+  EXPECT_TRUE(abs_error(norm_result, one_plus_delta) <= tolerance());
+
+  std::vector<Binary128> axpy_source{delta};
+  std::vector<Binary128> axpy_destination{Binary128{1}};
+  uni20::krylov::axpy(Binary128{1}, const_span(axpy_source), mutable_span(axpy_destination));
+  EXPECT_TRUE(abs_error(axpy_destination[0], one_plus_delta) <= tolerance());
+
+  uni20::krylov::Matrix<Binary128> matrix(1, 2);
+  matrix[0, 0] = one_plus_delta;
+  matrix[0, 1] = Binary128{-1};
+  std::vector<Binary128> vector{Binary128{1}, Binary128{1}};
+  std::vector<Binary128> output{Binary128{}};
+  uni20::krylov::gemv(Binary128{1}, matrix, const_span(vector), Binary128{}, mutable_span(output));
+  EXPECT_TRUE(abs_error(output[0], delta) <= tolerance());
+
+  uni20::krylov::Matrix<Binary128> rank_one(1, 1);
+  std::vector<Binary128> left{one_plus_delta};
+  std::vector<Binary128> right{Binary128{1}};
+  uni20::krylov::geru(Binary128{1}, const_span(left), const_span(right), rank_one);
+  EXPECT_TRUE(abs_error(rank_one[0, 0], one_plus_delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SolvesSymmetricTridiagonalEigenvectors)
+{
+  auto result = uni20::krylov::symmetric_tridiagonal_eigensystem(std::vector<Binary128>{Binary128{2}, Binary128{2}},
+                                                                 std::vector<Binary128>{Binary128{1}}, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], Binary128{3}) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 const x0 = result.eigenvectors[0, col];
+    Binary128 const x1 = result.eigenvectors[1, col];
+    Binary128 const residual0 = Binary128{2} * x0 + x1 - lambda * x0;
+    Binary128 const residual1 = x0 + Binary128{2} * x1 - lambda * x1;
+    Binary128 const residual_norm = std::sqrt(residual0 * residual0 + residual1 * residual1);
+    Binary128 const vector_norm = std::sqrt(x0 * x0 + x1 * x1);
+    EXPECT_TRUE(residual_norm <= tolerance());
+    EXPECT_TRUE(abs_error(vector_norm, Binary128{1}) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SymmetricTridiagonalEigenvaluesResolveGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  auto eigenvalues = uni20::krylov::symmetric_tridiagonal_eigenvalues(
+      std::vector<Binary128>{Binary128{1}, Binary128{1} + delta}, std::vector<Binary128>{offdiagonal});
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(eigenvalues.size(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(eigenvalues[1] > eigenvalues[0]);
+  EXPECT_TRUE(eigenvalues[1] - eigenvalues[0] > delta);
+  EXPECT_TRUE(abs_error(eigenvalues[0], expected_low) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1], expected_high) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ResolvesSymmetricTridiagonalGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  auto result = uni20::krylov::symmetric_tridiagonal_eigensystem(
+      std::vector<Binary128>{Binary128{1}, Binary128{1} + delta}, std::vector<Binary128>{offdiagonal}, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(result.eigenvalues[1] - result.eigenvalues[0] > delta);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 const x0 = result.eigenvectors[0, col];
+    Binary128 const x1 = result.eigenvectors[1, col];
+    Binary128 const residual0 = x0 + offdiagonal * x1 - lambda * x0;
+    Binary128 const residual1 = offdiagonal * x0 + (Binary128{1} + delta) * x1 - lambda * x1;
+    Binary128 const residual_norm = std::sqrt(residual0 * residual0 + residual1 * residual1);
+    EXPECT_TRUE(residual_norm <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, DivideAndConquerSymmetricTridiagonalResolvesGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  auto result = uni20::krylov::symmetric_tridiagonal_eigensystem_divide_and_conquer(
+      std::vector<Binary128>{Binary128{1}, Binary128{1} + delta}, std::vector<Binary128>{offdiagonal}, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 2);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(result.eigenvalues[1] - result.eigenvalues[0] > delta);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 const x0 = result.eigenvectors[0, col];
+    Binary128 const x1 = result.eigenvectors[1, col];
+    Binary128 const residual0 = x0 + offdiagonal * x1 - lambda * x0;
+    Binary128 const residual1 = offdiagonal * x0 + (Binary128{1} + delta) * x1 - lambda * x1;
+    Binary128 const residual_norm = std::sqrt(residual0 * residual0 + residual1 * residual1);
+    Binary128 const vector_norm = std::sqrt(x0 * x0 + x1 * x1);
+    EXPECT_TRUE(residual_norm <= tolerance());
+    EXPECT_TRUE(abs_error(vector_norm, Binary128{1}) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SelectedSymmetricTridiagonalResolvesGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  auto result = uni20::krylov::symmetric_tridiagonal_eigensystem_index_range(
+      std::vector<Binary128>{Binary128{1}, Binary128{1} + delta, Binary128{2}},
+      std::vector<Binary128>{offdiagonal, Binary128{}}, 0, 1, true);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  Binary128 const expected_low = center - radius;
+  Binary128 const expected_high = center + radius;
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.rows(), 3);
+  ASSERT_EQ(result.eigenvectors.cols(), 2);
+  EXPECT_EQ(static_cast<double>(expected_low), 1.0);
+  EXPECT_EQ(static_cast<double>(expected_high), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(result.eigenvalues[1] - result.eigenvalues[0] > delta);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], expected_low) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], expected_high) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvectors.cols(); ++col)
+  {
+    Binary128 const lambda = result.eigenvalues[col];
+    Binary128 const x0 = result.eigenvectors[0, col];
+    Binary128 const x1 = result.eigenvectors[1, col];
+    Binary128 const x2 = result.eigenvectors[2, col];
+    Binary128 const residual0 = x0 + offdiagonal * x1 - lambda * x0;
+    Binary128 const residual1 = offdiagonal * x0 + (Binary128{1} + delta) * x1 - lambda * x1;
+    Binary128 const residual2 = Binary128{2} * x2 - lambda * x2;
+    Binary128 const residual_norm = std::sqrt(residual0 * residual0 + residual1 * residual1 + residual2 * residual2);
+    Binary128 const vector_norm = std::sqrt(x0 * x0 + x1 * x1 + x2 * x2);
+    EXPECT_TRUE(residual_norm <= tolerance());
+    EXPECT_TRUE(abs_error(vector_norm, Binary128{1}) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ComputesRealSchurDecomposition)
+{
+  uni20::krylov::Matrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 0] = Binary128{-2};
+  matrix[0, 1] = Binary128{2};
+  matrix[1, 1] = Binary128{1};
+
+  auto result = uni20::krylov::real_schur(matrix, true);
+
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.blocks.size(), 1);
+  EXPECT_EQ(result.blocks[0].begin, 0);
+  EXPECT_EQ(result.blocks[0].size, 2);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(complex_abs(result.eigenvalues[0]), std::sqrt(Binary128{5})) <= tolerance());
+  EXPECT_TRUE(complex_abs(result.eigenvalues[1] - std::conj(result.eigenvalues[0])) <= tolerance());
+  ASSERT_EQ(result.schur_vectors.rows(), 2);
+  ASSERT_EQ(result.schur_vectors.cols(), 2);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, HessenbergSchurResolvesDiagonalGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> hessenberg(3, 3);
+  hessenberg[0, 0] = Binary128{1};
+  hessenberg[1, 1] = Binary128{1} + delta;
+  hessenberg[2, 2] = Binary128{2};
+  hessenberg[0, 1] = Binary128{1};
+  hessenberg[1, 2] = Binary128{1} / Binary128{3};
+
+  auto result = uni20::krylov::real_hessenberg_schur(std::move(hessenberg), true);
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+
+  ASSERT_EQ(eigenvalues.size(), 3);
+  ASSERT_EQ(result.blocks.size(), 3);
+  ASSERT_EQ(result.schur_vectors.rows(), 3);
+  ASSERT_EQ(result.schur_vectors.cols(), 3);
+  EXPECT_EQ(static_cast<double>(eigenvalues[0].real()), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[1].real() > eigenvalues[0].real());
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[2].real(), Binary128{2}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SolvesRealNonsymmetricEigenvalues)
+{
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{3};
+  matrix[1, 1] = Binary128{-1};
+  matrix[2, 2] = Binary128{2};
+
+  auto result = uni20::krylov::real_nonsymmetric_eigensystem(std::move(matrix), false);
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+
+  ASSERT_EQ(eigenvalues.size(), 3);
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{-1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{2}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[2].real(), Binary128{3}) <= tolerance());
+  EXPECT_TRUE(complex_abs(eigenvalues[0] - uni20::complex<Binary128>{Binary128{-1}, Binary128{}}) <= tolerance());
+  EXPECT_EQ(result.right_eigenvectors.rows(), 0);
+  EXPECT_EQ(result.right_eigenvectors.cols(), 0);
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ResolvesRealNonsymmetricEigenvalueGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[0, 1] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+
+  auto result = uni20::krylov::real_nonsymmetric_eigensystem(std::move(matrix), false);
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+
+  ASSERT_EQ(eigenvalues.size(), 2);
+  EXPECT_EQ(static_cast<double>(eigenvalues[0].real()), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[1].real() > eigenvalues[0].real());
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[0].imag(), Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].imag(), Binary128{}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ExpertRealNonsymmetricEigensystemReportsBinary128GapDiagnostics)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[0, 1] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+
+  auto result = uni20::krylov::real_nonsymmetric_expert_eigensystem(std::move(matrix), true);
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+
+  ASSERT_EQ(eigenvalues.size(), 2);
+  ASSERT_EQ(result.right_eigenvectors.rows(), 2);
+  ASSERT_EQ(result.right_eigenvectors.cols(), 2);
+  ASSERT_EQ(result.reciprocal_eigenvalue_condition_numbers.size(), 2);
+  ASSERT_EQ(result.reciprocal_eigenvector_condition_numbers.size(), 2);
+  ASSERT_EQ(result.balance_scale.size(), 2);
+  EXPECT_EQ(static_cast<double>(eigenvalues[0].real()), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[1].real() > eigenvalues[0].real());
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(result.balanced_matrix_norm > Binary128{});
+  EXPECT_LT(result.balanced_first, result.balanced_last_exclusive);
+  EXPECT_LE(result.balanced_last_exclusive, 2);
+  for (std::size_t index = 0; index < 2; ++index)
+  {
+    EXPECT_TRUE(result.reciprocal_eigenvalue_condition_numbers[index] > Binary128{});
+    EXPECT_TRUE(result.reciprocal_eigenvector_condition_numbers[index] > Binary128{});
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, BalancesRealNonsymmetricMatrixWithTinyBinary128Offdiagonal)
+{
+  Binary128 const tiny = binary_power_of_two(-8000);
+  expect_value_underflows_to_double_zero(tiny);
+
+  uni20::krylov::Matrix<Binary128> matrix(2, 2);
+  matrix[0, 1] = tiny;
+  matrix[1, 0] = Binary128{1};
+
+  auto result = uni20::krylov::real_nonsymmetric_balance(matrix, uni20::krylov::RealNonsymmetricBalanceJob::Scale);
+
+  ASSERT_EQ(result.balanced_matrix.rows(), 2);
+  ASSERT_EQ(result.balanced_matrix.cols(), 2);
+  ASSERT_EQ(result.scale.size(), 2);
+  EXPECT_LT(result.balanced_first, result.balanced_last_exclusive);
+  EXPECT_LE(result.balanced_last_exclusive, 2);
+  EXPECT_TRUE((result.balanced_matrix[0, 1] > Binary128{}));
+  EXPECT_EQ(static_cast<double>(result.balanced_matrix[0, 1]), 0.0);
+  EXPECT_TRUE((result.balanced_matrix[1, 0] > Binary128{}));
+
+  uni20::krylov::Matrix<Binary128> vectors(2, 1);
+  vectors[0, 0] = Binary128{1};
+  auto transformed = uni20::krylov::real_nonsymmetric_balance_backtransform_right_vectors(
+      vectors, result, uni20::krylov::RealNonsymmetricBalanceJob::Scale);
+
+  ASSERT_EQ(transformed.rows(), 2);
+  ASSERT_EQ(transformed.cols(), 1);
+  EXPECT_TRUE((transformed[0, 0] != Binary128{}));
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, BalancesRealGeneralizedNonsymmetricPencilWithTinyBinary128Offdiagonal)
+{
+  Binary128 const tiny = binary_power_of_two(-8000);
+  expect_value_underflows_to_double_zero(tiny);
+
+  uni20::krylov::Matrix<Binary128> matrix(2, 2);
+  matrix[0, 1] = tiny;
+  matrix[1, 0] = Binary128{1};
+
+  uni20::krylov::Matrix<Binary128> metric(2, 2);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{2};
+
+  auto result = uni20::krylov::real_generalized_nonsymmetric_balance(matrix, metric,
+                                                                     uni20::krylov::RealNonsymmetricBalanceJob::Scale);
+
+  ASSERT_EQ(result.balanced_matrix.rows(), 2);
+  ASSERT_EQ(result.balanced_matrix.cols(), 2);
+  ASSERT_EQ(result.balanced_metric.rows(), 2);
+  ASSERT_EQ(result.balanced_metric.cols(), 2);
+  ASSERT_EQ(result.left_scale.size(), 2);
+  ASSERT_EQ(result.right_scale.size(), 2);
+  EXPECT_LT(result.balanced_first, result.balanced_last_exclusive);
+  EXPECT_LE(result.balanced_last_exclusive, 2);
+  EXPECT_TRUE((result.balanced_matrix[0, 1] > Binary128{}));
+  EXPECT_EQ(static_cast<double>(result.balanced_matrix[0, 1]), 0.0);
+  EXPECT_TRUE((result.balanced_matrix[1, 0] > Binary128{}));
+
+  uni20::krylov::Matrix<Binary128> vectors(2, 1);
+  vectors[0, 0] = Binary128{1};
+  auto transformed = uni20::krylov::real_generalized_nonsymmetric_balance_backtransform_right_vectors(
+      vectors, result, uni20::krylov::RealNonsymmetricBalanceJob::Scale);
+
+  ASSERT_EQ(transformed.rows(), 2);
+  ASSERT_EQ(transformed.cols(), 1);
+  EXPECT_TRUE((transformed[0, 0] != Binary128{}));
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralizedHessenbergReductionPreservesBinary128OnlyEntry)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{3};
+  matrix[1, 0] = Binary128{2};
+  matrix[2, 0] = Binary128{-1};
+  matrix[0, 1] = Binary128{4};
+  matrix[1, 1] = Binary128{1} + delta;
+  matrix[2, 1] = Binary128{5};
+  matrix[0, 2] = Binary128{-2};
+  matrix[1, 2] = Binary128{1};
+  matrix[2, 2] = Binary128{6};
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 1.0);
+
+  DenseMatrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{2};
+  metric[0, 1] = Binary128{-1};
+  metric[1, 1] = Binary128{3};
+  metric[0, 2] = Binary128{1};
+  metric[1, 2] = Binary128{2};
+  metric[2, 2] = Binary128{4};
+
+  auto result = uni20::krylov::real_generalized_hessenberg_reduction(matrix, metric, true);
+  auto reconstructed_matrix =
+      multiply_for_test(multiply_for_test(result.left_orthogonal_vectors, result.matrix_hessenberg_form),
+                        transpose(result.right_orthogonal_vectors));
+  auto reconstructed_metric =
+      multiply_for_test(multiply_for_test(result.left_orthogonal_vectors, result.metric_triangular_form),
+                        transpose(result.right_orthogonal_vectors));
+
+  ASSERT_EQ(result.matrix_hessenberg_form.rows(), 3);
+  ASSERT_EQ(result.matrix_hessenberg_form.cols(), 3);
+  ASSERT_EQ(result.metric_triangular_form.rows(), 3);
+  ASSERT_EQ(result.metric_triangular_form.cols(), 3);
+  EXPECT_TRUE(abs_error(result.matrix_hessenberg_form[2, 0], Binary128{}) <= tolerance());
+  for (std::size_t col = 0; col < 3; ++col)
+  {
+    for (std::size_t row = col + 1; row < 3; ++row)
+    {
+      EXPECT_TRUE(abs_error(result.metric_triangular_form[row, col], Binary128{}) <= tolerance());
+      EXPECT_TRUE(abs_error(reconstructed_matrix[row, col], matrix[row, col]) <= tolerance());
+      EXPECT_TRUE(abs_error(reconstructed_metric[row, col], metric[row, col]) <= tolerance());
+    }
+  }
+  for (std::size_t row = 0; row < 3; ++row)
+  {
+    for (std::size_t col = 0; col < 3; ++col)
+    {
+      EXPECT_TRUE(abs_error(reconstructed_matrix[row, col], matrix[row, col]) <= tolerance());
+      EXPECT_TRUE(abs_error(reconstructed_metric[row, col], metric[row, col]) <= tolerance());
+    }
+  }
+  EXPECT_EQ(static_cast<double>(reconstructed_matrix[1, 1]), 1.0);
+  EXPECT_TRUE((reconstructed_matrix[1, 1] > Binary128{1}));
+  EXPECT_TRUE(abs_error(reconstructed_matrix[1, 1], Binary128{1} + delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralizedHessenbergSchurResolvesMetricGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> hessenberg(3, 3);
+  hessenberg[0, 0] = Binary128{1};
+  hessenberg[0, 1] = delta / Binary128{4};
+  hessenberg[1, 1] = Binary128{1};
+  hessenberg[1, 2] = Binary128{3} * delta;
+  hessenberg[2, 2] = Binary128{2};
+
+  DenseMatrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[0, 2] = delta / Binary128{8};
+  metric[1, 1] = Binary128{1} / (Binary128{1} + delta);
+  metric[2, 2] = Binary128{1};
+  EXPECT_EQ(static_cast<double>(metric[1, 1]), 1.0);
+
+  auto result = uni20::krylov::real_generalized_hessenberg_schur(hessenberg, metric, true);
+  auto reconstructed_matrix = multiply_for_test(multiply_for_test(result.left_schur_vectors, result.matrix_schur_form),
+                                                transpose(result.right_schur_vectors));
+  auto reconstructed_metric = multiply_for_test(multiply_for_test(result.left_schur_vectors, result.metric_schur_form),
+                                                transpose(result.right_schur_vectors));
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+
+  ASSERT_EQ(result.alpha.size(), 3);
+  ASSERT_EQ(result.beta.size(), 3);
+  ASSERT_EQ(eigenvalues.size(), 3);
+  ASSERT_EQ(result.left_schur_vectors.rows(), 3);
+  ASSERT_EQ(result.left_schur_vectors.cols(), 3);
+  ASSERT_EQ(result.right_schur_vectors.rows(), 3);
+  ASSERT_EQ(result.right_schur_vectors.cols(), 3);
+  EXPECT_EQ(static_cast<double>(eigenvalues[0].real()), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[1].real() > eigenvalues[0].real());
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[2].real(), Binary128{2}) <= tolerance());
+
+  for (std::size_t col = 0; col < 3; ++col)
+  {
+    for (std::size_t row = 0; row < 3; ++row)
+    {
+      EXPECT_TRUE(abs_error(reconstructed_matrix[row, col], hessenberg[row, col]) <= tolerance());
+      EXPECT_TRUE(abs_error(reconstructed_metric[row, col], metric[row, col]) <= tolerance());
+    }
+  }
+  for (std::size_t index = 0; index < result.alpha.size(); ++index)
+  {
+    EXPECT_TRUE(abs_error(result.beta[index], Binary128{}) > tolerance());
+    EXPECT_TRUE(complex_abs(result.alpha[index] / result.beta[index] - result.eigenvalues[index]) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ResolvesRealGeneralizedNonsymmetricEigenvalueGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{2} * (Binary128{1} + delta);
+  matrix[2, 2] = Binary128{6};
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 2.0);
+
+  uni20::krylov::Matrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{2};
+  metric[2, 2] = Binary128{3};
+
+  auto result = uni20::krylov::real_generalized_nonsymmetric_eigensystem(std::move(matrix), std::move(metric), true);
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+
+  ASSERT_EQ(result.alpha.size(), 3);
+  ASSERT_EQ(result.beta.size(), 3);
+  ASSERT_EQ(eigenvalues.size(), 3);
+  ASSERT_EQ(result.right_eigenvectors.rows(), 3);
+  ASSERT_EQ(result.right_eigenvectors.cols(), 3);
+  EXPECT_EQ(static_cast<double>(eigenvalues[0].real()), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[1].real() > eigenvalues[0].real());
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[2].real(), Binary128{2}) <= tolerance());
+
+  for (std::size_t col = 0; col < result.eigenvalues.size(); ++col)
+  {
+    EXPECT_TRUE(abs_error(result.beta[col], Binary128{}) > tolerance());
+    EXPECT_TRUE(complex_abs(result.alpha[col] / result.beta[col] - result.eigenvalues[col]) <= tolerance());
+
+    auto const lambda = result.eigenvalues[col];
+    Binary128 residual_norm{};
+    for (std::size_t row = 0; row < result.right_eigenvectors.rows(); ++row)
+    {
+      Binary128 const matrix_diagonal =
+          row == 0 ? Binary128{1} : (row == 1 ? Binary128{2} * (Binary128{1} + delta) : Binary128{6});
+      Binary128 const metric_diagonal = Binary128{1} + static_cast<Binary128>(row);
+      auto const value = result.right_eigenvectors[row, col];
+      auto const residual = matrix_diagonal * value - lambda * metric_diagonal * value;
+      Binary128 const residual_abs = complex_abs(residual);
+      residual_norm += residual_abs * residual_abs;
+    }
+    EXPECT_TRUE(std::sqrt(residual_norm) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ExpertRealGeneralizedNonsymmetricEigensystemReportsBinary128GapDiagnostics)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{2} * (Binary128{1} + delta);
+  matrix[2, 2] = Binary128{6};
+  EXPECT_EQ(static_cast<double>(matrix[1, 1]), 2.0);
+
+  uni20::krylov::Matrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{2};
+  metric[2, 2] = Binary128{3};
+
+  auto result =
+      uni20::krylov::real_generalized_nonsymmetric_expert_eigensystem(std::move(matrix), std::move(metric), true);
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+
+  ASSERT_EQ(result.alpha.size(), 3);
+  ASSERT_EQ(result.beta.size(), 3);
+  ASSERT_EQ(eigenvalues.size(), 3);
+  ASSERT_EQ(result.right_eigenvectors.rows(), 3);
+  ASSERT_EQ(result.right_eigenvectors.cols(), 3);
+  ASSERT_EQ(result.reciprocal_eigenvalue_condition_numbers.size(), 3);
+  ASSERT_EQ(result.reciprocal_eigenvector_condition_numbers.size(), 3);
+  ASSERT_EQ(result.left_balance_scale.size(), 3);
+  ASSERT_EQ(result.right_balance_scale.size(), 3);
+  EXPECT_EQ(static_cast<double>(eigenvalues[0].real()), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[1].real() > eigenvalues[0].real());
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[2].real(), Binary128{2}) <= tolerance());
+  EXPECT_TRUE(result.balanced_matrix_norm > Binary128{});
+  EXPECT_TRUE(result.balanced_metric_norm > Binary128{});
+  EXPECT_LT(result.balanced_first, result.balanced_last_exclusive);
+  EXPECT_LE(result.balanced_last_exclusive, 3);
+  for (std::size_t index = 0; index < 3; ++index)
+  {
+    EXPECT_TRUE(result.reciprocal_eigenvalue_condition_numbers[index] > Binary128{});
+    EXPECT_TRUE(result.reciprocal_eigenvector_condition_numbers[index] > Binary128{});
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, RealGeneralizedSchurResolvesMetricGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1};
+  matrix[2, 2] = Binary128{2};
+
+  uni20::krylov::Matrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{1} / (Binary128{1} + delta);
+  metric[2, 2] = Binary128{1};
+
+  auto result = uni20::krylov::real_generalized_schur(std::move(matrix), std::move(metric), false);
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+
+  ASSERT_EQ(eigenvalues.size(), 3);
+  ASSERT_EQ(result.alpha.size(), 3);
+  ASSERT_EQ(result.beta.size(), 3);
+  ASSERT_EQ(result.blocks.size(), 3);
+  EXPECT_EQ(static_cast<double>(eigenvalues[0].real()), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[1].real() > eigenvalues[0].real());
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[2].real(), Binary128{2}) <= tolerance());
+  EXPECT_EQ(result.left_schur_vectors.rows(), 0);
+  EXPECT_EQ(result.right_schur_vectors.rows(), 0);
+  for (std::size_t index = 0; index < result.alpha.size(); ++index)
+  {
+    EXPECT_TRUE(abs_error(result.beta[index], Binary128{}) > tolerance());
+    EXPECT_TRUE(complex_abs(result.alpha[index] / result.beta[index] - result.eigenvalues[index]) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ReordersGeneralizedSchurBlockSeparatedOnlyInBinary128)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1};
+  matrix[2, 2] = Binary128{2};
+
+  uni20::krylov::Matrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{1} / (Binary128{1} + delta);
+  metric[2, 2] = Binary128{1};
+
+  auto schur = uni20::krylov::real_generalized_schur(std::move(matrix), std::move(metric), true);
+  std::size_t target_block = schur.blocks.size();
+  for (std::size_t index = 0; index < schur.blocks.size(); ++index)
+  {
+    if (abs_error(schur.blocks[index].first_eigenvalue.real(), Binary128{1} + delta) <= tolerance())
+    {
+      target_block = index;
+    }
+  }
+  ASSERT_LT(target_block, schur.blocks.size());
+
+  auto reordered =
+      uni20::krylov::reorder_real_generalized_schur(std::move(schur), std::vector<std::size_t>{target_block});
+
+  ASSERT_GE(reordered.eigenvalues.size(), 3);
+  ASSERT_GE(reordered.blocks.size(), 3);
+  EXPECT_EQ(static_cast<double>(reordered.eigenvalues.front().real()), 1.0);
+  EXPECT_TRUE(reordered.eigenvalues.front().real() > Binary128{1});
+  EXPECT_TRUE(abs_error(reordered.eigenvalues.front().real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(complex_abs(reordered.alpha.front() / reordered.beta.front() - reordered.eigenvalues.front()) <=
+              tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SelectedGeneralizedSchurSubspaceKeepsBinary128SeparatedBlock)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1};
+  matrix[2, 2] = Binary128{2};
+
+  uni20::krylov::Matrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{1} / (Binary128{1} + delta);
+  metric[2, 2] = Binary128{1};
+
+  auto schur = uni20::krylov::real_generalized_schur(std::move(matrix), std::move(metric), true);
+  std::size_t target_block = schur.blocks.size();
+  for (std::size_t index = 0; index < schur.blocks.size(); ++index)
+  {
+    if (abs_error(schur.blocks[index].first_eigenvalue.real(), Binary128{1} + delta) <= tolerance())
+    {
+      target_block = index;
+    }
+  }
+  ASSERT_LT(target_block, schur.blocks.size());
+
+  auto result =
+      uni20::krylov::real_generalized_schur_selected_subspace(std::move(schur), std::vector<std::size_t>{target_block});
+
+  ASSERT_GE(result.decomposition.eigenvalues.size(), 3);
+  EXPECT_EQ(result.selected_dimension, 1);
+  EXPECT_EQ(static_cast<double>(result.decomposition.eigenvalues.front().real()), 1.0);
+  EXPECT_TRUE(result.decomposition.eigenvalues.front().real() > Binary128{1});
+  EXPECT_TRUE(abs_error(result.decomposition.eigenvalues.front().real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(complex_abs(result.decomposition.alpha.front() / result.decomposition.beta.front() -
+                          result.decomposition.eigenvalues.front()) <= tolerance());
+  EXPECT_TRUE(result.left_projection_lower_bound > Binary128{});
+  EXPECT_TRUE(result.right_projection_lower_bound > Binary128{});
+  EXPECT_TRUE(result.upper_deflating_subspace_separation > Binary128{});
+  EXPECT_TRUE(result.lower_deflating_subspace_separation > Binary128{});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralizedSchurRightEigenvectorsUseBinary128OnlyGap)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1};
+  matrix[2, 2] = Binary128{2};
+
+  uni20::krylov::Matrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{1} / (Binary128{1} + delta);
+  metric[2, 2] = Binary128{1};
+
+  auto schur = uni20::krylov::real_generalized_schur(std::move(matrix), std::move(metric), false);
+  auto matrix_schur_form = schur.matrix_schur_form;
+  auto metric_schur_form = schur.metric_schur_form;
+  auto eigenvalues = schur.eigenvalues;
+  auto eigenvectors = uni20::krylov::real_generalized_schur_right_eigenvectors(std::move(schur));
+
+  ASSERT_EQ(eigenvectors.computed_vectors, 3);
+  ASSERT_EQ(eigenvectors.right_eigenvectors.rows(), 3);
+  std::size_t target_column = eigenvalues.size();
+  for (std::size_t col = 0; col < eigenvalues.size(); ++col)
+  {
+    if (abs_error(eigenvalues[col].real(), Binary128{1} + delta) <= tolerance())
+    {
+      target_column = col;
+    }
+    EXPECT_TRUE(generalized_schur_right_eigenvector_residual_max(matrix_schur_form, metric_schur_form, eigenvalues[col],
+                                                                 eigenvectors.right_eigenvectors, col) <= tolerance());
+  }
+  ASSERT_LT(target_column, eigenvalues.size());
+  EXPECT_EQ(static_cast<double>(eigenvalues[target_column].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[target_column].real() > Binary128{1});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, GeneralizedSchurConditionEstimatesUseBinary128OnlyGap)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1};
+  matrix[2, 2] = Binary128{2};
+
+  uni20::krylov::Matrix<Binary128> metric(3, 3);
+  metric[0, 0] = Binary128{1};
+  metric[1, 1] = Binary128{1} / (Binary128{1} + delta);
+  metric[2, 2] = Binary128{1};
+
+  auto schur = uni20::krylov::real_generalized_schur(std::move(matrix), std::move(metric), false);
+  auto eigenvalues = schur.eigenvalues;
+  auto result = uni20::krylov::real_generalized_schur_condition_estimates(std::move(schur));
+
+  ASSERT_EQ(result.computed_estimates, 3);
+  ASSERT_EQ(result.reciprocal_eigenvalue_condition_numbers.size(), 3);
+  ASSERT_EQ(result.reciprocal_eigenvector_condition_numbers.size(), 3);
+  std::size_t target_column = eigenvalues.size();
+  for (std::size_t col = 0; col < eigenvalues.size(); ++col)
+  {
+    if (abs_error(eigenvalues[col].real(), Binary128{1} + delta) <= tolerance())
+    {
+      target_column = col;
+    }
+    EXPECT_TRUE(result.reciprocal_eigenvalue_condition_numbers[col] > Binary128{});
+    EXPECT_TRUE(result.reciprocal_eigenvector_condition_numbers[col] >= Binary128{});
+  }
+  ASSERT_LT(target_column, eigenvalues.size());
+  Binary128 const min_eigenvector_condition =
+      *std::ranges::min_element(result.reciprocal_eigenvector_condition_numbers);
+  EXPECT_TRUE(min_eigenvector_condition > Binary128{});
+  EXPECT_TRUE(min_eigenvector_condition < static_cast<Binary128>(1.0e-20L));
+  EXPECT_EQ(static_cast<double>(eigenvalues[target_column].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[target_column].real() > Binary128{1});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ReordersRealSchurBlocks)
+{
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{3};
+  matrix[2, 2] = Binary128{2};
+
+  auto schur = uni20::krylov::real_schur(matrix, true);
+  std::size_t target_block = schur.blocks.size();
+  for (std::size_t index = 0; index < schur.blocks.size(); ++index)
+  {
+    if (abs_error(schur.blocks[index].first_eigenvalue.real(), Binary128{3}) <= tolerance())
+    {
+      target_block = index;
+    }
+  }
+  ASSERT_LT(target_block, schur.blocks.size());
+
+  auto reordered = uni20::krylov::reorder_real_schur(std::move(schur), std::vector<std::size_t>{target_block});
+
+  ASSERT_FALSE(reordered.eigenvalues.empty());
+  EXPECT_TRUE(abs_error(reordered.eigenvalues.front().real(), Binary128{3}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ReordersSchurBlockSeparatedOnlyInBinary128)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  matrix[2, 2] = Binary128{2};
+
+  auto schur = uni20::krylov::real_schur(matrix, true);
+  std::size_t target_block = schur.blocks.size();
+  for (std::size_t index = 0; index < schur.blocks.size(); ++index)
+  {
+    if (abs_error(schur.blocks[index].first_eigenvalue.real(), Binary128{1} + delta) <= tolerance())
+    {
+      target_block = index;
+    }
+  }
+  ASSERT_LT(target_block, schur.blocks.size());
+
+  auto reordered = uni20::krylov::reorder_real_schur(std::move(schur), std::vector<std::size_t>{target_block});
+
+  ASSERT_GE(reordered.eigenvalues.size(), 3);
+  EXPECT_EQ(static_cast<double>(reordered.eigenvalues.front().real()), 1.0);
+  EXPECT_TRUE(reordered.eigenvalues.front().real() > Binary128{1});
+  EXPECT_TRUE(abs_error(reordered.eigenvalues.front().real(), Binary128{1} + delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SelectedSchurSubspaceKeepsBinary128SeparatedBlock)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  matrix[2, 2] = Binary128{2};
+
+  auto schur = uni20::krylov::real_schur(matrix, true);
+  std::size_t target_block = schur.blocks.size();
+  for (std::size_t index = 0; index < schur.blocks.size(); ++index)
+  {
+    if (abs_error(schur.blocks[index].first_eigenvalue.real(), Binary128{1} + delta) <= tolerance())
+    {
+      target_block = index;
+    }
+  }
+  ASSERT_LT(target_block, schur.blocks.size());
+
+  auto result = uni20::krylov::real_schur_selected_subspace(std::move(schur), std::vector<std::size_t>{target_block});
+
+  ASSERT_EQ(result.selected_dimension, 1);
+  ASSERT_GE(result.decomposition.eigenvalues.size(), 3);
+  EXPECT_EQ(static_cast<double>(result.decomposition.eigenvalues.front().real()), 1.0);
+  EXPECT_TRUE(result.decomposition.eigenvalues.front().real() > Binary128{1});
+  EXPECT_TRUE(abs_error(result.decomposition.eigenvalues.front().real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(result.reciprocal_eigenvalue_cluster_condition > Binary128{});
+  EXPECT_TRUE(result.reciprocal_invariant_subspace_condition > Binary128{});
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SchurRightEigenvectorsUseBinary128OnlyGap)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::RealSchurDecomposition<Binary128> schur;
+  schur.schur_form = DenseMatrix<Binary128>(2, 2);
+  schur.schur_form[0, 0] = Binary128{1};
+  schur.schur_form[0, 1] = Binary128{1};
+  schur.schur_form[1, 1] = Binary128{1} + delta;
+  schur.schur_vectors = identity_matrix(2);
+  schur.eigenvalues =
+      std::vector<uni20::complex<Binary128>>{uni20::complex<Binary128>{Binary128{1}, Binary128{}},
+                                             uni20::complex<Binary128>{Binary128{1} + delta, Binary128{}}};
+  schur.blocks = std::vector<uni20::krylov::RealSchurBlock<Binary128>>{
+      uni20::krylov::RealSchurBlock<Binary128>{
+          .begin = 0, .size = 1, .first_eigenvalue = schur.eigenvalues[0], .second_eigenvalue = {}},
+      uni20::krylov::RealSchurBlock<Binary128>{
+          .begin = 1, .size = 1, .first_eigenvalue = schur.eigenvalues[1], .second_eigenvalue = {}}};
+
+  auto const schur_form = schur.schur_form;
+  auto const eigenvalues = schur.eigenvalues;
+  auto result = uni20::krylov::real_schur_right_eigenvectors(std::move(schur));
+
+  ASSERT_EQ(result.computed_vectors, 2);
+  ASSERT_EQ(result.right_eigenvectors.rows(), 2);
+  ASSERT_EQ(result.right_eigenvectors.cols(), 2);
+  for (std::size_t column = 0; column < 2; ++column)
+  {
+    EXPECT_TRUE(schur_right_eigenvector_residual_max(schur_form, eigenvalues[column], result.right_eigenvectors,
+                                                     column) <= Binary128{100} * tolerance());
+  }
+
+  auto const x0 = result.right_eigenvectors[0, 1];
+  auto const x1 = result.right_eigenvectors[1, 1];
+  ASSERT_GT(complex_abs(x0), Binary128{});
+  auto const ratio = x1 / x0;
+  EXPECT_TRUE(abs_error(ratio.real(), delta) <= Binary128{100} * tolerance());
+  EXPECT_TRUE(abs_error(ratio.imag(), Binary128{}) <= Binary128{100} * tolerance());
+  EXPECT_TRUE(complex_abs(x1) > Binary128{});
+  EXPECT_TRUE(complex_abs(x1) < Binary128{1} / binary_power_of_two(60));
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SchurConditionEstimatesUseBinary128OnlyGap)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::RealSchurDecomposition<Binary128> schur;
+  schur.schur_form = DenseMatrix<Binary128>(2, 2);
+  schur.schur_form[0, 0] = Binary128{1};
+  schur.schur_form[0, 1] = Binary128{1};
+  schur.schur_form[1, 1] = Binary128{1} + delta;
+  schur.schur_vectors = identity_matrix(2);
+  schur.eigenvalues =
+      std::vector<uni20::complex<Binary128>>{uni20::complex<Binary128>{Binary128{1}, Binary128{}},
+                                             uni20::complex<Binary128>{Binary128{1} + delta, Binary128{}}};
+  schur.blocks = std::vector<uni20::krylov::RealSchurBlock<Binary128>>{
+      uni20::krylov::RealSchurBlock<Binary128>{
+          .begin = 0, .size = 1, .first_eigenvalue = schur.eigenvalues[0], .second_eigenvalue = {}},
+      uni20::krylov::RealSchurBlock<Binary128>{
+          .begin = 1, .size = 1, .first_eigenvalue = schur.eigenvalues[1], .second_eigenvalue = {}}};
+
+  auto result = uni20::krylov::real_schur_condition_estimates(std::move(schur));
+
+  ASSERT_EQ(result.computed_estimates, 2);
+  ASSERT_EQ(result.reciprocal_eigenvalue_condition_numbers.size(), 2);
+  ASSERT_EQ(result.reciprocal_eigenvector_condition_numbers.size(), 2);
+  Binary128 min_vector_condition = result.reciprocal_eigenvector_condition_numbers[0];
+  for (std::size_t index = 0; index < 2; ++index)
+  {
+    EXPECT_TRUE(result.reciprocal_eigenvalue_condition_numbers[index] > Binary128{});
+    EXPECT_TRUE(result.reciprocal_eigenvector_condition_numbers[index] > Binary128{});
+    min_vector_condition = std::min(min_vector_condition, result.reciprocal_eigenvector_condition_numbers[index]);
+  }
+  EXPECT_TRUE(min_vector_condition < Binary128{1} / binary_power_of_two(60));
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, SolvesNearlySingularDenseSystemBelowDoubleResolution)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{1};
+  matrix[0, 1] = Binary128{1};
+  matrix[1, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+
+  DenseMatrix<Binary128> rhs(2, 1);
+  rhs[0, 0] = Binary128{2};
+  rhs[1, 0] = Binary128{2} + delta;
+
+  auto solution = uni20::linalg::backends::cpu::solve_linear_system(std::move(matrix), std::move(rhs));
+
+  ASSERT_EQ(solution.rows(), 2);
+  ASSERT_EQ(solution.cols(), 1);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{1}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, ScalarMatrixExponentialResolvesBelowDoublePrecisionIncrement)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(1, 1);
+  matrix[0, 0] = delta;
+
+  auto result = uni20::linalg::backends::cpu::matrix_exponential(matrix, Binary128{1});
+
+  ASSERT_EQ(result.rows(), 1);
+  ASSERT_EQ(result.cols(), 1);
+  EXPECT_EQ(static_cast<double>(result[0, 0]), 1.0);
+  EXPECT_TRUE((result[0, 0] > Binary128{1}));
+  EXPECT_TRUE(abs_error((result[0, 0] - Binary128{1}), delta) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, UpperTriangularMatrixExponentialPreservesBinary128OnlyIncrements)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = delta;
+  matrix[0, 1] = delta;
+  matrix[1, 0] = Binary128{};
+  matrix[1, 1] = Binary128{2} * delta;
+
+  auto result = uni20::linalg::backends::cpu::matrix_exponential(matrix, Binary128{1});
+
+  ASSERT_EQ(result.rows(), 2);
+  ASSERT_EQ(result.cols(), 2);
+  EXPECT_EQ(static_cast<double>(result[0, 0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result[1, 1]), 1.0);
+  EXPECT_TRUE((result[0, 0] > Binary128{1}));
+  EXPECT_TRUE((result[1, 1] > Binary128{1}));
+  EXPECT_TRUE(abs_error((result[0, 0] - Binary128{1}), delta) <= tolerance());
+  EXPECT_TRUE(abs_error((result[1, 1] - Binary128{1}), Binary128{2} * delta) <= tolerance());
+  EXPECT_TRUE(abs_error(result[0, 1], delta) <= tolerance());
+  EXPECT_TRUE(abs_error(result[1, 0], Binary128{}) <= tolerance());
+}
+
+TEST(MplapackBinary128DenseSubspaceTest, HighNormMatrixExponentialPreservesSmallBinary128BlockIncrement)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  DenseMatrix<Binary128> matrix(2, 2);
+  matrix[0, 0] = Binary128{6};
+  matrix[0, 1] = Binary128{};
+  matrix[1, 0] = Binary128{};
+  matrix[1, 1] = delta;
+
+  auto result = uni20::linalg::backends::cpu::matrix_exponential(matrix, Binary128{1});
+
+  ASSERT_EQ(result.rows(), 2);
+  ASSERT_EQ(result.cols(), 2);
+  EXPECT_TRUE((result[0, 0] > Binary128{400}));
+  EXPECT_EQ(static_cast<double>(result[1, 1]), 1.0);
+  EXPECT_TRUE((result[1, 1] > Binary128{1}));
+  EXPECT_TRUE(abs_error((result[1, 1] - Binary128{1}), delta) <= tolerance());
+  EXPECT_TRUE(abs_error(result[0, 1], Binary128{}) <= tolerance());
+  EXPECT_TRUE(abs_error(result[1, 0], Binary128{}) <= tolerance());
+}
+
+} // namespace

--- a/tests/krylov/test_mplapack_binary128_krylov_solvers.cpp
+++ b/tests/krylov/test_mplapack_binary128_krylov_solvers.cpp
@@ -1,0 +1,323 @@
+#include <mplapack_config.h>
+#include <uni20/krylov/dense_host_vector.hpp>
+#include <uni20/krylov/dense_subspace.hpp>
+#include <uni20/krylov/krylov_exponential.hpp>
+#include <uni20/krylov/nonsymmetric_arnoldi.hpp>
+#include <uni20/krylov/symmetric_lanczos.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE == MPLAPACK_BINARY128_MODE_LDBL)
+
+TEST(MplapackBinary128KrylovSolversTest, SkipsLongDoubleAliasMode)
+{
+  GTEST_SKIP() << "configured MPLAPACK binary128 mode aliases long double";
+}
+
+#else
+
+namespace
+{
+
+using Binary128 = mplapack_binary128_t;
+using ComplexBinary128 = uni20::complex<Binary128>;
+using Vector = uni20::krylov::DenseHostVector<Binary128>;
+using ComplexVector = uni20::krylov::DenseHostVector<ComplexBinary128>;
+using Ops = uni20::krylov::DenseHostVectorOps<Binary128>;
+using ComplexOps = uni20::krylov::DenseHostVectorOps<ComplexBinary128>;
+
+Binary128 abs_error(Binary128 actual, Binary128 expected) { return std::abs(actual - expected); }
+
+Binary128 tolerance() { return static_cast<Binary128>(1.0e-25L); }
+
+Binary128 binary_power_of_two(int exponent)
+{
+  Binary128 result{1};
+  if (exponent >= 0)
+  {
+    for (int i = 0; i < exponent; ++i)
+    {
+      result *= Binary128{2};
+    }
+  }
+  else
+  {
+    for (int i = 0; i < -exponent; ++i)
+    {
+      result /= Binary128{2};
+    }
+  }
+  return result;
+}
+
+Binary128 below_double_resolution_gap() { return binary_power_of_two(-80); }
+
+void expect_gap_is_binary128_only(Binary128 gap)
+{
+  EXPECT_TRUE(Binary128{1} + gap > Binary128{1});
+  EXPECT_EQ(static_cast<double>(Binary128{1} + gap), 1.0);
+}
+
+void expect_value_increment_is_binary128_only(Binary128 value)
+{
+  EXPECT_TRUE(value > Binary128{1});
+  EXPECT_EQ(static_cast<double>(value), 1.0);
+}
+
+std::vector<Binary128> diagonal_dense_matrix(std::vector<Binary128> const& diagonal)
+{
+  std::size_t const dimension = diagonal.size();
+  std::vector<Binary128> matrix(dimension * dimension, Binary128{});
+  for (std::size_t i = 0; i < dimension; ++i)
+  {
+    matrix[i * dimension + i] = diagonal[i];
+  }
+  return matrix;
+}
+
+Binary128 vector_norm(Vector const& vector)
+{
+  Binary128 sum{};
+  for (Binary128 const value : vector.values)
+  {
+    sum += value * value;
+  }
+  return sum > Binary128{} ? std::sqrt(sum) : Binary128{};
+}
+
+Binary128 relative_residual(Ops& ops, Vector const& eigenvector, Binary128 eigenvalue)
+{
+  Vector residual = ops.allocate_like(eigenvector);
+  ops.matvec(residual, eigenvector);
+  ops.axpy(residual, -eigenvalue, eigenvector);
+  Binary128 const residual_norm = vector_norm(residual);
+  Binary128 const scale = std::max(Binary128{1}, std::abs(eigenvalue) * vector_norm(eigenvector));
+  return residual_norm / scale;
+}
+
+} // namespace
+
+TEST(MplapackBinary128KrylovSolversTest, TridiagonalProjectionResolvesGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const offdiagonal = delta / Binary128{4};
+  expect_gap_is_binary128_only(delta);
+
+  std::vector<Binary128> diagonal{Binary128{1}, Binary128{1} + delta, Binary128{2}};
+  std::vector<Binary128> subdiagonal{offdiagonal, Binary128{}};
+  auto result = uni20::krylov::symmetric_tridiagonal_eigensystem(diagonal, subdiagonal, false);
+
+  Binary128 const center = Binary128{1} + delta / Binary128{2};
+  Binary128 const radius = std::sqrt((delta / Binary128{2}) * (delta / Binary128{2}) + offdiagonal * offdiagonal);
+  ASSERT_EQ(result.eigenvalues.size(), 3);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(result.eigenvalues[1]), 1.0);
+  EXPECT_TRUE(result.eigenvalues[1] > result.eigenvalues[0]);
+  EXPECT_TRUE(abs_error(result.eigenvalues[0], center - radius) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1], center + radius) <= tolerance());
+}
+
+TEST(MplapackBinary128KrylovSolversTest, SymmetricLanczosResolvesDiagonalGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  Ops ops(4, diagonal_dense_matrix({Binary128{1}, Binary128{1} + delta, Binary128{2}, Binary128{3}}));
+  Vector initial{{Binary128{1}, Binary128{1}, Binary128{1}, Binary128{1}}};
+
+  uni20::krylov::SymmetricEigenParams<Binary128> params;
+  params.eigenvalue_count = 2;
+  params.krylov_dimension = 4;
+  params.tolerance = tolerance();
+  params.spectrum = uni20::krylov::SpectrumPart::SmallestAlgebraic;
+  params.compute_eigenvectors = true;
+
+  auto result = uni20::krylov::symmetric_lanczos_standard<Binary128>(ops, initial, params);
+
+  ASSERT_EQ(result.status, 0);
+  ASSERT_EQ(result.converged_count, 2);
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.eigenvectors.size(), 2);
+
+  std::vector<Binary128> eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues);
+  EXPECT_EQ(static_cast<double>(eigenvalues[0]), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1]), 1.0);
+  EXPECT_TRUE(eigenvalues[1] > eigenvalues[0]);
+  EXPECT_TRUE(abs_error(eigenvalues[0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1], Binary128{1} + delta) <= tolerance());
+
+  for (std::size_t i = 0; i < result.eigenvectors.size(); ++i)
+  {
+    EXPECT_TRUE(relative_residual(ops, result.eigenvectors[i], result.eigenvalues[i]) <= tolerance());
+  }
+}
+
+TEST(MplapackBinary128KrylovSolversTest, RealSchurAndReorderUseBinary128ProjectedLAPACK)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> matrix(3, 3);
+  matrix[0, 0] = Binary128{1};
+  matrix[1, 1] = Binary128{1} + delta;
+  matrix[2, 2] = Binary128{3};
+  matrix[0, 2] = Binary128{0.125};
+  matrix[1, 2] = Binary128{0.25};
+
+  auto schur = uni20::krylov::real_schur(matrix, true);
+  ASSERT_EQ(schur.eigenvalues.size(), 3);
+  auto reordered = uni20::krylov::reorder_real_schur(std::move(schur), std::vector<std::size_t>{2});
+
+  ASSERT_EQ(reordered.eigenvalues.size(), 3);
+  EXPECT_TRUE(abs_error(reordered.eigenvalues[0].real(), Binary128{3}) <= tolerance());
+  EXPECT_TRUE(abs_error(reordered.eigenvalues[0].imag(), Binary128{}) <= tolerance());
+}
+
+TEST(MplapackBinary128KrylovSolversTest, RealHessenbergSchurUsesBinary128ProjectedLAPACK)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<Binary128> hessenberg(3, 3);
+  hessenberg[0, 0] = Binary128{1};
+  hessenberg[1, 1] = Binary128{1} + delta;
+  hessenberg[2, 2] = Binary128{2};
+  hessenberg[0, 2] = Binary128{0.125};
+  hessenberg[1, 2] = Binary128{0.25};
+
+  auto schur = uni20::krylov::real_hessenberg_schur(hessenberg, true);
+  ASSERT_EQ(schur.eigenvalues.size(), 3);
+  std::ranges::sort(schur.eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+  EXPECT_TRUE(abs_error(schur.eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(schur.eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+}
+
+TEST(MplapackBinary128KrylovSolversTest, RealArnoldiResolvesTriangularGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  std::vector<Binary128> matrix{
+      Binary128{1}, Binary128{0},         Binary128{0.125}, Binary128{0},    //
+      Binary128{0}, Binary128{1} + delta, Binary128{0},     Binary128{0},    //
+      Binary128{0}, Binary128{0},         Binary128{2},     Binary128{0.25}, //
+      Binary128{0}, Binary128{0},         Binary128{0},     Binary128{3},
+  };
+  Ops ops(4, matrix);
+  Vector initial{{Binary128{1}, Binary128{1}, Binary128{1}, Binary128{1}}};
+
+  uni20::krylov::NonsymmetricEigenParams<Binary128> params;
+  params.eigenvalue_count = 2;
+  params.krylov_dimension = 4;
+  params.tolerance = tolerance();
+  params.complex_pair_tolerance = tolerance();
+  params.spectrum = uni20::krylov::SpectrumPart::SmallestReal;
+  params.compute_eigenvectors = true;
+
+  auto result = uni20::krylov::real_nonsymmetric_arnoldi_standard(ops, initial, params);
+
+  ASSERT_EQ(result.status, uni20::krylov::NonsymmetricStatus::Converged);
+  ASSERT_EQ(result.converged_count, 2);
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  ASSERT_EQ(result.right_eigenvectors.size(), 2);
+
+  auto eigenvalues = result.eigenvalues;
+  std::ranges::sort(eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+  EXPECT_EQ(static_cast<double>(eigenvalues[0].real()), 1.0);
+  EXPECT_EQ(static_cast<double>(eigenvalues[1].real()), 1.0);
+  EXPECT_TRUE(eigenvalues[1].real() > eigenvalues[0].real());
+  EXPECT_TRUE(abs_error(eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+}
+
+TEST(MplapackBinary128KrylovSolversTest, ComplexSchurAndReorderUseBinary128ProjectedLAPACK)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  uni20::krylov::Matrix<ComplexBinary128> matrix(3, 3);
+  matrix[0, 0] = ComplexBinary128{Binary128{1}, delta};
+  matrix[1, 1] = ComplexBinary128{Binary128{1} + delta, Binary128{2} * delta};
+  matrix[2, 2] = ComplexBinary128{Binary128{3}, Binary128{}};
+  matrix[0, 2] = ComplexBinary128{Binary128{0.125}, Binary128{}};
+  matrix[1, 2] = ComplexBinary128{Binary128{0.25}, Binary128{}};
+
+  auto schur = uni20::krylov::complex_schur<Binary128>(matrix, true);
+  ASSERT_EQ(schur.eigenvalues.size(), 3);
+  auto reordered = uni20::krylov::reorder_complex_schur(std::move(schur), std::vector<std::size_t>{2});
+
+  ASSERT_EQ(reordered.eigenvalues.size(), 3);
+  EXPECT_TRUE(abs_error(reordered.eigenvalues[0].real(), Binary128{3}) <= tolerance());
+  EXPECT_TRUE(abs_error(reordered.eigenvalues[0].imag(), Binary128{}) <= tolerance());
+}
+
+TEST(MplapackBinary128KrylovSolversTest, ComplexArnoldiResolvesComplexGapBelowDoublePrecision)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  expect_gap_is_binary128_only(delta);
+
+  std::vector<ComplexBinary128> matrix{
+      ComplexBinary128{Binary128{1}, delta},
+      ComplexBinary128{}, //
+      ComplexBinary128{},
+      ComplexBinary128{Binary128{1} + delta, Binary128{2} * delta},
+  };
+  ComplexOps ops(2, matrix);
+  ComplexVector initial{{ComplexBinary128{Binary128{1}, Binary128{}}, ComplexBinary128{Binary128{1}, Binary128{}}}};
+
+  uni20::krylov::NonsymmetricEigenParams<Binary128> params;
+  params.eigenvalue_count = 2;
+  params.krylov_dimension = 2;
+  params.tolerance = tolerance();
+  params.complex_pair_tolerance = tolerance();
+  params.spectrum = uni20::krylov::SpectrumPart::SmallestReal;
+  params.compute_eigenvectors = false;
+
+  auto result = uni20::krylov::complex_nonsymmetric_arnoldi_standard<Binary128>(ops, initial, params);
+
+  ASSERT_EQ(result.status, uni20::krylov::NonsymmetricStatus::Converged);
+  ASSERT_EQ(result.converged_count, 2);
+  ASSERT_EQ(result.eigenvalues.size(), 2);
+  std::ranges::sort(result.eigenvalues, [](auto const& lhs, auto const& rhs) { return lhs.real() < rhs.real(); });
+  EXPECT_TRUE(abs_error(result.eigenvalues[0].real(), Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1].real(), Binary128{1} + delta) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[0].imag(), delta) <= tolerance());
+  EXPECT_TRUE(abs_error(result.eigenvalues[1].imag(), Binary128{2} * delta) <= tolerance());
+}
+
+TEST(MplapackBinary128KrylovSolversTest, HermitianExponentialActionPreservesBinary128OnlyIncrement)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const exp_delta = std::exp(delta);
+  Binary128 const exp_two_delta = std::exp(Binary128{2} * delta);
+  expect_value_increment_is_binary128_only(exp_delta);
+  expect_value_increment_is_binary128_only(exp_two_delta);
+
+  std::vector<Binary128> matrix{
+      delta,
+      Binary128{}, //
+      Binary128{},
+      Binary128{2} * delta,
+  };
+  Ops ops(2, matrix);
+  Vector initial{{Binary128{1}, Binary128{-1}}};
+
+  uni20::krylov::KrylovExponentialParams<Binary128> params;
+  params.krylov_dimension = 2;
+
+  auto result = uni20::krylov::hermitian_krylov_exponential_action<Binary128>(ops, initial, Binary128{1}, params);
+
+  ASSERT_EQ(result.projected_dimension, 2);
+  ASSERT_EQ(result.matvec_count, 2);
+  EXPECT_TRUE(abs_error(result.action.values[0], exp_delta) <= tolerance());
+  EXPECT_TRUE(abs_error(result.action.values[1], -exp_two_delta) <= tolerance());
+}
+
+#endif

--- a/tests/linalg/test_mplapack_binary128_cpu_ops.cpp
+++ b/tests/linalg/test_mplapack_binary128_cpu_ops.cpp
@@ -1,0 +1,112 @@
+#include <mplapack_config.h>
+#include <uni20/linalg/linalg.hpp>
+#include <uni20/tensor/basic_tensor.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <concepts>
+
+#if defined(MPLAPACK_BINARY128_MODE) && (MPLAPACK_BINARY128_MODE == MPLAPACK_BINARY128_MODE_LDBL)
+
+TEST(MplapackBinary128CpuOpsTest, SkipsLongDoubleAliasMode)
+{
+  GTEST_SKIP() << "configured MPLAPACK binary128 mode aliases long double";
+}
+
+#else
+
+namespace
+{
+
+using Binary128 = mplapack_binary128_t;
+using index_t = uni20::index_type;
+using extents_2d = stdex::dextents<index_t, 2>;
+using tensor_type = uni20::BasicTensor<Binary128, extents_2d, uni20::VectorStorage>;
+
+Binary128 abs_error(Binary128 actual, Binary128 expected) { return std::abs(actual - expected); }
+
+Binary128 tolerance() { return static_cast<Binary128>(1.0e-25L); }
+
+Binary128 binary_power_of_two(int exponent)
+{
+  Binary128 result{1};
+  if (exponent >= 0)
+  {
+    for (int i = 0; i < exponent; ++i)
+    {
+      result *= Binary128{2};
+    }
+  }
+  else
+  {
+    for (int i = 0; i < -exponent; ++i)
+    {
+      result /= Binary128{2};
+    }
+  }
+  return result;
+}
+
+Binary128 below_double_resolution_gap() { return binary_power_of_two(-80); }
+
+Binary128 below_double_minimum_value() { return binary_power_of_two(-1200); }
+
+void expect_gap_is_binary128_only(Binary128 gap)
+{
+  EXPECT_TRUE(Binary128{1} + gap > Binary128{1});
+  EXPECT_EQ(static_cast<double>(Binary128{1} + gap), 1.0);
+}
+
+void expect_value_underflows_to_double_zero(Binary128 value)
+{
+  EXPECT_GT(value, Binary128{});
+  EXPECT_EQ(static_cast<double>(value), 0.0);
+}
+
+} // namespace
+
+TEST(MplapackBinary128CpuOpsTest, TensorMatrixOneNormPreservesBinary128Accumulation)
+{
+  Binary128 const delta = below_double_resolution_gap();
+  Binary128 const one_plus_delta = Binary128{1} + delta;
+  expect_gap_is_binary128_only(delta);
+
+  tensor_type matrix(extents_2d{2, 2});
+  matrix[0, 0] = one_plus_delta;
+  matrix[1, 0] = Binary128{1};
+  matrix[0, 1] = Binary128{1};
+  matrix[1, 1] = Binary128{};
+
+  auto const norm = uni20::linalg::matrix_one_norm(matrix.const_view());
+  static_assert(std::same_as<decltype(norm), Binary128 const>);
+
+  EXPECT_EQ(static_cast<double>(norm), 2.0);
+  EXPECT_TRUE(norm > Binary128{2});
+  EXPECT_TRUE(abs_error(norm, Binary128{2} + delta) <= tolerance());
+}
+
+TEST(MplapackBinary128CpuOpsTest, TensorSolveAcceptsPivotsBelowDoubleMinimum)
+{
+  Binary128 const tiny = below_double_minimum_value();
+  expect_value_underflows_to_double_zero(tiny);
+
+  tensor_type matrix(extents_2d{2, 2});
+  matrix[0, 0] = tiny;
+  matrix[0, 1] = Binary128{};
+  matrix[1, 0] = Binary128{};
+  matrix[1, 1] = tiny;
+
+  tensor_type rhs(extents_2d{2, 1});
+  rhs[0, 0] = tiny;
+  rhs[1, 0] = Binary128{2} * tiny;
+
+  auto solution = uni20::linalg::solve_linear_system(matrix.const_view(), rhs.const_view());
+
+  ASSERT_EQ(solution.extents().extent(0), 2);
+  ASSERT_EQ(solution.extents().extent(1), 1);
+  EXPECT_TRUE(abs_error(solution[0, 0], Binary128{1}) <= tolerance());
+  EXPECT_TRUE(abs_error(solution[1, 0], Binary128{2}) <= tolerance());
+}
+
+#endif


### PR DESCRIPTION
## Summary

This adds an optional MPLAPACK-backed binary128 lapack wrappers that work with the existing Krlov routines.

The new support is gated behind `UNI20_ENABLE_MPLAPACK=ON`. Uni20 does not download or build MPLAPACK during configure; developers provide an external MPLAPACK package. The ordinary default build and ordinary `s/d/c/z` Krylov test matrix remain separate from the binary128 probes.

This PR adds:

- optional MPLAPACK binary128 detection/configuration
- binary128 MPBLAS wrappers
- MPLAPACK LAPACK wrappers for dense projected real/complex helper kernels
- gated binary128 tests for scalar policy, BLAS/LAPACK wrappers, linalg CPU
  helpers, Krylov dense-subspace helpers, and Krylov solvers
- setup documentation for building MPLAPACK externally
- a carried local MPLAPACK CMake detector patch for current upstream
  compatibility

Unused dense projected wrappers are intentionally kept out of the ordinary typed
solver matrix, but remain in-tree and tested through the gated `MplapackBinary128*` targets.
